### PR TITLE
Implementation of ResourceSync 1.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+DSpaceResourceSync.iml
 *.bak
 ## Ignore the MVN compiled output directories from version tracking
 target/
@@ -34,3 +35,5 @@ META-INF/
 rebel.xml
 .externalToolBuilders/
 local.cfg
+
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,36 @@
-.idea/
-DSpaceResourceSync.iml
+*.bak
+## Ignore the MVN compiled output directories from version tracking
 target/
+
+## Ignore project files created by Eclipse
+.settings/
+/bin/
+.project
+.classpath
+
+## Ignore project files created by IntelliJ IDEA
+*.iml
+*.ipr
+*.iws
+.idea/
+overlays/
+
+## Ignore project files created by NetBeans
+nbproject/private/
+build/
+nbbuild/
+dist/
+nbdist/
+nbactions.xml
+nb-configuration.xml
+META-INF/
+
+## Ignore all *.properties file in root folder, EXCEPT build.properties (the default)
+/*.properties
+!/build.properties
+
+##Mac noise
+.DS_Store
+rebel.xml
+.externalToolBuilders/
+local.cfg

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,13 @@
+Copyright (c) 2002-2018, DuraSpace.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+See https://opensource.org/licenses/BSD-3-Clause

--- a/LICENSE_HEADER
+++ b/LICENSE_HEADER
@@ -1,0 +1,3 @@
+The contents of this file are subject to the license and copyright
+detailed in the LICENSE and NOTICE files at the root of the source
+tree

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,6 @@
+
+Licensing Notice
+
+The project is based on code initially developed by Richard Jones at CottageLabs. 
+In May 2018 the copyright was waived in favour of the DuraSpace Foundation to 
+allow wide contribution and simplify the adoption by the DSpace community.

--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
-#DSpace ResourceSync Module
+# DSpace ResourceSync Module
 
 This module provides ResourceSync capabilities for DSpace, supporting the metadata harvesting use case. It is based on the original work from Richard Jones of CottageLabs. 4Science has used fund from OpenAIRE to update, extend and improve it, see https://www.openaire.eu/openaire-tender-calls-winners
 
 **Please note this is the version for DSpace 5, check these other branches for a version compatible with [DSpace 6](https://github.com/4Science/DSpaceResourceSync/tree/D4CRIS-506-D6) and [DSpace 7](https://github.com/4Science/DSpaceResourceSync/tree/D4CRIS-506-D7)
 
-##Dependencies
+## Dependencies
 
 This module depends on a generic ResourceSync Java library, which you will need to install before you can
 build the code
 
     https://github.com/4Science/ResourceSyncJava
 
-##Installation
+## Installation
 
 The software can be compiled with simply
 
@@ -39,15 +39,15 @@ You can then deploy the dspace-resourcesync webapp in tomcat alongside your DSpa
 
 You must also deploy the resourcesync.cfg file into the DSpace config/modules directory.
 
-##Usage
+## Usage
 
 In order to provide the ResourceSync documents via the webapp, you need to generate the documents.
 
-###Create the initial Resource List
+### Create the initial Resource List
 
     ./dspace dsrun org.dspace.resourcesync.ResourceSyncGenerator -i
 
-###Update the Change Lists periodically
+### Update the Change Lists periodically
 
 This will generate a new Change List every time it is run, and make it available via the Change List Archive.  It is
 best to run this as a cron job, at a frequency suitable to the rate of change of the content in your repository (for
@@ -55,13 +55,13 @@ example, once a week).
 
     ./dspace dsrun org.dspace.resourcesync.ResourceSyncGenerator -u
 
-###Rebase the documents periodically
+### Rebase the documents periodically
 
 This will generate an up-to-date Resource List and a new Change List every time it is run.  It is best to run this as
 a cron job at a longer frequency suitable to the rate of change of the content in your repository (for example, once
 a month)
 
-##Configuration
+## Configuration
 
 Configuration can be found in dspace/config/modules/resourcesync.cfg
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This module provides ResourceSync capabilities for DSpace, supporting the metadata harvesting use case. It is based on the original work from Richard Jones of CottageLabs. 4Science has used fund from OpenAIRE to update, extend and improve it, see https://www.openaire.eu/openaire-tender-calls-winners
 
-**Please note this is the version for DSpace 5, check these other branches for a version compatible with [DSpace 6](https://github.com/4Science/DSpaceResourceSync/tree/D4CRIS-506-D6) and [DSpace 7](https://github.com/4Science/DSpaceResourceSync/tree/D4CRIS-506-D7)
+**Please note this is the version for DSpace 5, check these other branches for a version compatible with [DSpace 6](https://github.com/4Science/DSpaceResourceSync/tree/D4CRIS-506-D6) and [DSpace 7](https://github.com/4Science/DSpaceResourceSync/tree/D4CRIS-506-D7)**
 
 ## Dependencies
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,15 @@
 #DSpace ResourceSync Module
 
-This module provides ResourceSync capabilities for DSpace, supporting the metadata harvesting use case.
+This module provides ResourceSync capabilities for DSpace, supporting the metadata harvesting use case. It is based on the original work from Richard Jones of CottageLabs. 4Science has used fund from OpenAIRE to update, extend and improve it, see https://www.openaire.eu/openaire-tender-calls-winners
+
+**Please note this is the version for DSpace 5, check these other branches for a version compatible with [DSpace 6](https://github.com/4Science/DSpaceResourceSync/tree/D4CRIS-506-D6) and [DSpace 7](https://github.com/4Science/DSpaceResourceSync/tree/D4CRIS-506-D7)
 
 ##Dependencies
 
 This module depends on a generic ResourceSync Java library, which you will need to install before you can
 build the code
 
-    https://github.com/CottageLabs/ResourceSyncJava
+    https://github.com/4Science/ResourceSyncJava
 
 ##Installation
 
@@ -26,7 +28,7 @@ and then update your dspace pom.xml file to depend on this module, with a depend
     <dependency>
         <groupId>org.dspace</groupId>
         <artifactId>dspace-resourcesync</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.1-SNAPSHOT</version>
         <type>jar</type>
         <classifier>classes</classifier>
     </dependency>

--- a/dspace/config/modules/resourcesync.cfg
+++ b/dspace/config/modules/resourcesync.cfg
@@ -1,15 +1,21 @@
 # Base URL for the ResourceSync webapp
 #
-base-url = ${dspace.baseUrl}/dspace-resourcesync
+
+resourcesync.baseUrl = ${dspace.baseUrl}
+# If you want run the resourcesync webapp on another host/port please define your custom base-url
+#resourcesync.baseUrl = http://<hostname>:<port>
+
+base-url = ${resourcesync.baseUrl}/dspace-resourcesync
 
 # Directory where ResourceSync static documents will be stored
 #
 resourcesync.dir = ${dspace.dir}/resourcesync
-
 # List of bundles to expose via ResourceSync, comma separated list.  If this option is omitted or no bundles
 # are specified, then no bitstreams will be exposed.
 #
 expose-bundles = ORIGINAL
+
+solr.server = ${solr.server}/resourcesync
 
 # NOTE: the metadata prefix for the dublin core terms is "qdc" here because we also use the prefix
 # to load the dissemination crosswalk.  DSpace is already configured by default to offer a qualified
@@ -49,10 +55,12 @@ bitstream.change-freq = never
 #
 changelist.include-restricted = false
 
+# site | all (site+community+collections) | top (find top community) | manual
+capabilitylists = site
 # URL to point users of the Capability List to in order to read more about the capabilities of the
 # repository.  If left blank or omitted, no link will be provided in the Capability List
 #
-capabilitylist.described-by = ${dspace.baseUrl}/dspace-resourcesync/about.txt
+capabilitylist.described-by = ${resourcesync.baseUrl}/dspace-resourcesync/about.txt
 
 # Should we generate a resourcedump when we initialise or rebase?
 #
@@ -64,3 +72,7 @@ capabilitylist.described-by = ${dspace.baseUrl}/dspace-resourcesync/about.txt
 # that allows us to more closely manage the size of these files
 #
 resourcedump.enable = true
+resourcedump.onthefly = true
+changedump.onthefly = true
+resourcedump.onlymetadata = true
+usage-statistcs.track.download = true

--- a/manifest.xml
+++ b/manifest.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sm:urlset xmlns:sm="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:rs="http://www.openarchives.org/rs/terms/">
+  <rs:md capability="changedump-manifest" from="2018-05-11T16:16:11Z" />
+  <rs:ln rel="up" href="http://petrucci.local.it:8082/dspace-resourcesync/123456789-11/capabilitylist.xml" />
+</sm:urlset>

--- a/pom.xml
+++ b/pom.xml
@@ -9,6 +9,10 @@
     <version>1.0-SNAPSHOT</version>
     <packaging>war</packaging>
 
+	<properties>
+        <root.basedir>${basedir}</root.basedir>
+    </properties>
+    
     <build>
         <plugins>
             <plugin>
@@ -44,6 +48,61 @@
                     </execution>
                 </executions>
             </plugin>
+         	<plugin>
+                <groupId>com.mycila</groupId>
+                <artifactId>license-maven-plugin</artifactId>
+                <configuration>
+                    <!-- License header file (can be a URL, but that's less stable if external site is down on occasion) -->
+                    <header>${root.basedir}/LICENSE_HEADER</header>
+                    <!--Just check headers of everything in the /src directory -->
+                    <includes>
+                        <include>src/**</include>
+                    </includes>
+                    <!--Use all default exclusions for IDE files & Maven files, see: 
+                        http://code.google.com/p/maven-license-plugin/wiki/Configuration#Default_excludes -->
+                    <useDefaultExcludes>true</useDefaultExcludes>
+                    <!-- Add some default DSpace exclusions not covered by <useDefaultExcludes> 
+                         Individual Maven projects may choose to override these defaults. -->
+                    <excludes>
+                        <exclude>**/src/test/resources/**</exclude>
+                        <exclude>**/src/test/data/**</exclude>
+                        <exclude>**/src/main/license/**</exclude>
+                        <exclude>**/testEnvironment.properties</exclude>
+                        <exclude>**/META-INF/**</exclude>
+                        <exclude>**/robots.txt</exclude>
+                        <exclude>**/*.LICENSE</exclude>
+                        <exclude>**/LICENSE*</exclude>
+                        <exclude>**/README*</exclude>
+                        <exclude>**/readme*</exclude>
+                        <exclude>**/.gitignore</exclude>
+                        <exclude>**/build.properties*</exclude>
+                        <exclude>**/rebel.xml</exclude>
+                    </excludes>
+                    <mapping> 
+                        <!-- Custom DSpace file extensions which are not recognized by maven-release-plugin: 
+                             *.xmap, *.xslt, *.wsdd, *.wsdl, *.ttl, *.LICENSE -->
+                        <xmap>XML_STYLE</xmap>
+                        <xslt>XML_STYLE</xslt>
+                        <wsdd>XML_STYLE</wsdd>
+                        <wsdl>XML_STYLE</wsdl>
+                        <ttl>SCRIPT_STYLE</ttl>
+                        <LICENSE>TEXT</LICENSE>
+                    </mapping>  
+                    <encoding>UTF-8</encoding>
+                    <!-- maven-license-plugin recommends a strict check (e.g. check spaces/tabs too) -->
+                    <strictCheck>true</strictCheck>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>check-headers</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+         	</plugin>
+            
         </plugins>
     </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,29 +1,30 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
 
-    <groupId>org.dspace</groupId>
-    <artifactId>dspace-resourcesync</artifactId>
-    <version>1.0-SNAPSHOT</version>
-    <packaging>war</packaging>
+	<groupId>org.dspace</groupId>
+	<artifactId>dspace-resourcesync</artifactId>
+	<version>1.1-SNAPSHOT</version>
+	<packaging>war</packaging>
 
 	<properties>
-        <root.basedir>${basedir}</root.basedir>
-    </properties>
-    
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.1</version>
-                <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
-                </configuration>
-            </plugin>
+		<dspace.version>5.9-SNAPSHOT</dspace.version>
+		<root.basedir>${basedir}</root.basedir>
+	</properties>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.1</version>
+				<configuration>
+					<source>1.8</source>
+					<target>1.8</target>
+				</configuration>
+			</plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
@@ -102,34 +103,57 @@
                     </execution>
                 </executions>
          	</plugin>
-            
-        </plugins>
-    </build>
+	
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-war-plugin</artifactId>
+				<configuration>
+					<attachClasses>true</attachClasses>
+					<!-- In version 2.1-alpha-1, this was incorrectly named warSourceExcludes -->
+<!-- 					<packagingExcludes>WEB-INF/lib/*.jar</packagingExcludes>
+					<warSourceExcludes>WEB-INF/lib/*.jar</warSourceExcludes> -->
+					<webResources>
+						<resource>
+							<filtering>true</filtering>
+							<directory>${basedir}/src/main/webapp</directory>
+							<includes>
+								<include>WEB-INF/web.xml</include>
+							</includes>
+						</resource>
+					</webResources>
+				</configuration>
+				<executions>
+					<execution>
+						<phase>prepare-package</phase>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
 
-    <dependencies>
-        <dependency>
-            <groupId>org.dspace</groupId>
-            <artifactId>dspace-api</artifactId>
-            <version>3.0</version>
-        </dependency>
+	<dependencies>
+		<dependency>
+			<groupId>org.dspace</groupId>
+			<artifactId>dspace-api</artifactId>
+			<version>${dspace.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.openarchives</groupId>
+			<artifactId>resourcesync</artifactId>
+			<version>1.1-SNAPSHOT</version>
+		</dependency>
 
-        <dependency>
-            <groupId>org.openarchives</groupId>
-            <artifactId>resourcesync</artifactId>
-            <version>0.9-SNAPSHOT</version>
-        </dependency>
+		<dependency>
+			<groupId>commons-cli</groupId>
+			<artifactId>commons-cli</artifactId>
+			<version>1.0</version>
+		</dependency>
 
-        <dependency>
-            <groupId>commons-cli</groupId>
-            <artifactId>commons-cli</artifactId>
-            <version>1.0</version>
-        </dependency>
+		<dependency>
+			<groupId>javax.servlet</groupId>
+			<artifactId>servlet-api</artifactId>
+			<version>2.4</version>
+		</dependency>
+	</dependencies>
 
-        <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
-            <version>2.4</version>
-        </dependency>
-    </dependencies>
-    
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -138,7 +138,7 @@
 			<version>${dspace.version}</version>
 		</dependency>
 		<dependency>
-			<groupId>org.openarchives</groupId>
+			<groupId>org.dspace</groupId>
 			<artifactId>resourcesync</artifactId>
 			<version>1.1-SNAPSHOT</version>
 		</dependency>

--- a/src/main/java/org/dspace/resourcesync/BitstreamRetrieveServlet.java
+++ b/src/main/java/org/dspace/resourcesync/BitstreamRetrieveServlet.java
@@ -1,0 +1,239 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree
+ */
+package org.dspace.resourcesync;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import javax.mail.internet.MimeUtility;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.apache.log4j.Logger;
+import org.dspace.authorize.AuthorizeException;
+import org.dspace.content.Bitstream;
+import org.dspace.content.Bundle;
+import org.dspace.core.ConfigurationManager;
+import org.dspace.core.Context;
+import org.dspace.core.LogManager;
+import org.dspace.core.Utils;
+import org.dspace.usage.UsageEvent;
+import org.dspace.utils.DSpace;
+
+/**
+ * Servlet for retrieving bitstreams in a UI indipendent way. The bits are simply piped to the user.
+ * Taken from org.dspace.app.webui.servlet.RetrieveServlet
+ * <P>
+ * <code>/bitstreams/bitstream-id</code>
+ * 
+ * @author Andrea Bollini (andrea.bollini at 4science.it)
+ * @author Andrea Petrucci (andrea.petrucci at 4science.it)
+ * 
+ */
+public class BitstreamRetrieveServlet extends HttpServlet
+{
+    /**
+	 * 
+	 */
+	private static final long serialVersionUID = 1L;
+
+	/** log4j category */
+    private static Logger log = Logger.getLogger(BitstreamRetrieveServlet.class);
+
+    /**
+	 * Pattern used to get file.ext from filename (which can be a path)
+	 */
+	private static Pattern p = Pattern.compile("[^/]*$");
+
+    /**
+     * Threshold on Bitstream size before content-disposition will be set.
+     */
+    private int threshold;
+    
+    
+    
+    private boolean isResourceSyncRelevant(Bundle bnd) {
+		if (bnd == null)
+			return false;
+		return ResourceSyncConfiguration.getBundlesToExpose().contains(bnd.getName());
+	}
+    @Override
+    public void doGet(HttpServletRequest request,
+            HttpServletResponse response) throws ServletException, IOException
+    {
+    	Context context = null;
+    	try
+        {
+    		context = new Context();
+    		Bitstream bitstream = null;
+    		// prendere il bundle dalla conf rs    		
+    		
+    		// sostituire con bundle rilevante o no
+    		boolean isRelevant = false;
+    		//boolean isLicense = false;
+
+
+    		// Get the ID from the URL
+    		String idString = request.getPathInfo();
+
+    		if (idString != null)
+    		{
+    			// Remove leading slash
+    			if (idString.startsWith("/"))
+    			{
+    				idString = idString.substring(1);
+    			}
+
+    			// If there's a second slash, remove it and anything after it,
+    			// it might be a filename
+    			int slashIndex = idString.indexOf('/');
+
+    			if (slashIndex != -1)
+    			{
+    				idString = idString.substring(0, slashIndex);
+    			}
+
+    			// Find the corresponding bitstream
+    			try
+    			{
+    				int id = Integer.parseInt(idString);
+    				bitstream = Bitstream.find(context, id);
+    			}
+    			catch (NumberFormatException nfe)
+    			{
+    	        	log.error(nfe.getMessage(),nfe);
+
+    				// Invalid ID - this will be dealt with below
+    			}
+    		}
+
+    		// Did we get a bitstream?
+    		if (bitstream != null)
+    		{
+
+    			// Check whether we got a License and if it should be displayed
+    			// (Note: list of bundles may be empty array, if a bitstream is a Community/Collection logo)
+    			Bundle bundle = bitstream.getBundles().length>0 ? bitstream.getBundles()[0] : null;
+    			isRelevant = isResourceSyncRelevant(bundle);
+//    			if (bundle!=null && 
+//    					bundle.getName().equals(Constants.LICENSE_BUNDLE_NAME) &&
+//    					bitstream.getName().equals(Constants.LICENSE_BITSTREAM_NAME))
+//    			{
+//    				isLicense = true;
+//    			}
+    			if (!isRelevant)
+    			{
+    				throw new AuthorizeException();
+    			}
+    			log.info(LogManager.getHeader(context, "rs_bitstream",
+    					"bitstream_id=" + bitstream.getID()));
+
+    			// aggiungi un if su parametro di conf rs usage-statistcs.track.download
+    			boolean usageStatistics = ConfigurationManager.getBooleanProperty("resourcesync","");
+    			if (usageStatistics)
+    			{
+    				new DSpace().getEventService().fireEvent(
+    					new UsageEvent(
+    							UsageEvent.Action.VIEW,
+    							request, 
+    							context, 
+    							bitstream));
+    			}
+    			//UsageEvent ue = new UsageEvent();
+    			// ue.fire(request, context, AbstractUsageEvent.VIEW,
+    			//Constants.BITSTREAM, bitstream.getID());
+
+    			// Pipe the bits
+    			InputStream is = bitstream.retrieve();
+
+    			// Set the response MIME type
+    			response.setContentType(bitstream.getFormat().getMIMEType());
+
+    			// Response length
+    			response.setHeader("Content-Length", String.valueOf(bitstream
+    					.getSize()));
+
+    			if(threshold != -1 && bitstream.getSize() >= threshold)
+    			{
+    				setBitstreamDisposition(bitstream.getName(), request, response);
+    			}
+
+    			Utils.bufferedCopy(is, response.getOutputStream());
+    			is.close();
+    			response.getOutputStream().flush();
+    		}
+    		else
+    		{
+    			// No bitstream - we got an invalid ID
+    			log.info(LogManager.getHeader(context, "rs_bitstream",
+    					"invalid_bitstream_id=" + idString));
+
+    			// return NOT_FOUND
+    			response.sendError(HttpServletResponse.SC_NOT_FOUND);
+				return;
+    		}
+        }catch(Exception e) {
+        	log.error(e.getMessage(),e);
+        }finally {
+        	if (context != null && context.isValid())
+        	{
+        		context.abort();
+        	}
+        }
+    }
+    
+    /**
+	 * Evaluate filename and client and encode appropriate disposition
+	 *
+	 * @param filename
+	 * @param request
+	 * @param response
+	 * @throws UnsupportedEncodingException
+	 */
+	public static void setBitstreamDisposition(String filename, HttpServletRequest request,
+			HttpServletResponse response)
+	{
+
+		String name = filename;
+
+		Matcher m = p.matcher(name);
+
+		if (m.find() && !m.group().equals(""))
+		{
+			name = m.group();
+		}
+
+		try
+		{
+			String agent = request.getHeader("USER-AGENT");
+
+			if (null != agent && -1 != agent.indexOf("MSIE"))
+			{
+				name = URLEncoder.encode(name, "UTF8");
+			}
+			else if (null != agent && -1 != agent.indexOf("Mozilla"))
+			{
+				name = MimeUtility.encodeText(name, "UTF8", "B");
+			}
+
+		}
+		catch (UnsupportedEncodingException e)
+		{
+			log.error(e.getMessage(),e);
+		}
+		finally
+		{
+			response.setHeader("Content-Disposition", "attachment;filename=" + name);
+		}
+	}
+
+}

--- a/src/main/java/org/dspace/resourcesync/DSpaceCapabilityList.java
+++ b/src/main/java/org/dspace/resourcesync/DSpaceCapabilityList.java
@@ -26,9 +26,12 @@ public class DSpaceCapabilityList
     private boolean changeListArchive;
     private boolean resourceDump;
     private boolean changeList;
+    private boolean changeDump;
     private String latestChangeList;
+    private String latestChangeDump;
 
-    public DSpaceCapabilityList(Context context, boolean resourceList, boolean changeListArchive, boolean resourceDump, boolean changeList, String latestChangeList)
+    public DSpaceCapabilityList(Context context, boolean resourceList, boolean changeListArchive, boolean resourceDump, boolean changeList,
+    		boolean changeDump,String latestChangeList,String latestChangeDump,UrlManager um)
     {
         this.context = context;
         this.describedBy = ConfigurationManager.getProperty("resourcesync", "capabilitylist.described-by");
@@ -36,12 +39,14 @@ public class DSpaceCapabilityList
         {
             this.describedBy = null;
         }
-        this.um = new UrlManager();
+        this.um = um;
         this.resourceList = resourceList;
         this.changeListArchive = changeListArchive;
         this.resourceDump = resourceDump;
         this.changeList = changeList;
         this.latestChangeList = latestChangeList;
+        this.changeDump = changeDump;
+        this.latestChangeDump = latestChangeDump;
     }
 
     public void serialise(OutputStream out)
@@ -67,14 +72,18 @@ public class DSpaceCapabilityList
         }
         if (rsdUrl != null)
         {
-            cl.addLn(ResourceSync.REL_RESOURCESYNC, rsdUrl);
+            cl.addLn(ResourceSync.REL_UP, rsdUrl);
         }
 
         if (this.changeList && this.latestChangeList != null)
         {
             cl.setChangeList(this.latestChangeList);
         }
-
+        if (this.changeDump && this.latestChangeDump != null)
+        {
+            cl.setChangeDump(this.latestChangeDump);
+        }
+       
         cl.serialise(out);
     }
 }

--- a/src/main/java/org/dspace/resourcesync/DSpaceCapabilityList.java
+++ b/src/main/java/org/dspace/resourcesync/DSpaceCapabilityList.java
@@ -1,3 +1,8 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree
+ */
 package org.dspace.resourcesync;
 
 import org.dspace.core.ConfigurationManager;
@@ -8,6 +13,10 @@ import org.openarchives.resourcesync.ResourceSync;
 import java.io.IOException;
 import java.io.OutputStream;
 
+/**
+ * @author Richard Jones
+ *
+ */
 public class DSpaceCapabilityList
 {
     private Context context;

--- a/src/main/java/org/dspace/resourcesync/DSpaceChangeDump.java
+++ b/src/main/java/org/dspace/resourcesync/DSpaceChangeDump.java
@@ -6,34 +6,31 @@
 package org.dspace.resourcesync;
 
 import org.dspace.core.Context;
-import org.openarchives.resourcesync.ResourceDump;
-
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.sql.SQLException;
+import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.List;
 /**
- * @author Richard Jones
+ * @author Richard Jones 
  * @author Andrea Bollini (andrea.bollini at 4science.it)
  * @author Andrea Petrucci (andrea.petrucci at 4science.it)
- *
  */
-public class DSpaceResourceDump extends DSpaceResourceDocument
+public class DSpaceChangeDump extends DSpaceResourceDocument
 {
 	protected String metadataChangeFreq = null;
 	protected String bitstreamChangeFreq = null;
 
-	public DSpaceResourceDump(Context context)
+	public DSpaceChangeDump(Context context)
 	{
 		super(context);
 		this.metadataChangeFreq = this.getMetadataChangeFreq();
 		this.bitstreamChangeFreq = this.getBitstreamChangeFreq();
 	}
 
-	public DSpaceResourceDump(Context context, List<String> exposeBundles, List<MetadataFormat> mdFormats,
+	public DSpaceChangeDump(Context context, List<String> exposeBundles, List<MetadataFormat> mdFormats,
 			String mdChangeFreq, String bitstreamChangeFreq)
 	{
 		super(context, exposeBundles, mdFormats);
@@ -41,31 +38,24 @@ public class DSpaceResourceDump extends DSpaceResourceDocument
 		this.bitstreamChangeFreq = bitstreamChangeFreq;
 	}
 
-	public void serialise(String rdDir, String handle,UrlManager um)
+
+	public void serialiseChangeDump(String rdDir, UrlManager um,List<ResourceSyncEvent> rseList)
 			throws IOException, SQLException
 	{
+		SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd-HHmmss");
+		String date = sdf.format(new Date());
+		String rdFile = rdDir + File.separator + FileNames.changeDump(date);
 		// this generates the manifest file and zip file
-		
-		DSpaceResourceDumpZip drl = new DSpaceResourceDumpZip(this.context,rdDir);
-		drl.serialise(handle,um); // no output stream required
-		// now generate the dump file for the resourcesync framework
-		
-		ResourceDump rd = new ResourceDump(new Date(), um.capabilityList());
-		rd.addResourceZip(um.resourceDumpZip(), new Date(), "application/zip", this.getDumpSize(rdDir));
-
-		String rdFile = rdDir + File.separator + FileNames.resourceDump;
-		FileOutputStream fos = new FileOutputStream(new File(rdFile));
-		rd.serialise(fos);
-		fos.close();
+		DSpaceChangeDumpZip drl = new DSpaceChangeDumpZip(this.context,rdFile);
+		drl.serialise(um,rseList); // no output stream required
 	}
-	public synchronized void serialise(String handle,UrlManager um,OutputStream os)
+	public synchronized void serialiseChangeDump(String handle,UrlManager um,List<ResourceSyncEvent> rseList,OutputStream os)
 			throws IOException, SQLException
 	{
-		DSpaceResourceDumpZip drl = new DSpaceResourceDumpZip(this.context,os);
-		drl.serialise(handle,um); // no output stream required
-		drl.getZos().close();
+		DSpaceChangeDumpZip dcl = new DSpaceChangeDumpZip(this.context,os);
+		dcl.serialise(um,rseList); // no output stream required
+		dcl.getZos().close();
 	}
-
 	private long getDumpSize(String dir)
 	{
 		String path = dir + File.separator + FileNames.resourceDumpZip;

--- a/src/main/java/org/dspace/resourcesync/DSpaceChangeDumpZip.java
+++ b/src/main/java/org/dspace/resourcesync/DSpaceChangeDumpZip.java
@@ -1,0 +1,224 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree
+ */
+package org.dspace.resourcesync;
+
+
+import org.apache.log4j.Logger;
+import org.dspace.authorize.AuthorizeException;
+import org.dspace.content.Bitstream;
+import org.dspace.content.Collection;
+import org.dspace.content.Item;
+import org.dspace.content.crosswalk.CrosswalkException;
+import org.dspace.core.Context;
+import org.openarchives.resourcesync.ResourceSyncDocument;
+import org.openarchives.resourcesync.URL;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.sql.SQLException;
+import java.util.List;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+/**
+ * @author Richard Jones
+ * @author Andrea Bollini (andrea.bollini at 4science.it)
+ * @author Andrea Petrucci (andrea.petrucci at 4science.it)
+ */
+public class DSpaceChangeDumpZip  extends DSpaceResourceList
+{
+	private String dumpPathFile;
+	private ZipOutputStream zos;
+	private ZipOutputStream zosOnTheFly;
+	boolean isOnTheFly = false;
+	private OutputStream baos;
+    private static Logger log = Logger.getLogger(DSpaceChangeDumpZip.class);
+
+	public DSpaceChangeDumpZip(Context context,String dumpPathFile)
+    {
+    	super(context, true);
+		this.dumpPathFile = dumpPathFile;
+		this.isOnTheFly = false;
+    }
+
+	public DSpaceChangeDumpZip(Context context,OutputStream os) {
+		super(context, true);
+		this.isOnTheFly = true;
+		this.baos = os;
+	}
+
+	public ZipOutputStream getZos() {
+		if (isOnTheFly) {
+			if (this.zosOnTheFly == null) {
+				zosOnTheFly = new ZipOutputStream(baos);
+			}
+			return zosOnTheFly;
+		} else {
+			if (this.zos == null) {
+				try {
+					this.zos = new ZipOutputStream(
+							new FileOutputStream(this.dumpPathFile));
+				} catch (FileNotFoundException e) {
+					log.error(e.getMessage(),e);
+				}
+			}
+			return zos;
+		}
+	}
+   
+
+    
+    public void serialise(UrlManager um,List<ResourceSyncEvent> rseList)
+            throws SQLException, IOException
+    {
+        // first generate the manifest file.  This uses the other overrides in this object
+        // to also copy in the bitstreams and metadata serialisations which are relevant
+        // everything will be added to the zip
+    	if(!isOnTheFly) {
+	        String drlFile = FileNames.changeDumpManifest;
+	        FileOutputStream fos = new FileOutputStream(new File(drlFile));
+	        this.serialise(fos,um,rseList);
+	        
+	        
+	        // incorporate the manifest into the zip
+	        File manifest = new File(drlFile);
+	        FileInputStream is = new FileInputStream(manifest);
+	
+	        this.copyToZip(FileNames.changeDumpManifest, is);
+	
+	        getZos().close();
+	
+	        // get rid of the left over manifest file
+	        manifest.delete();
+    	}
+    	else
+    	{
+    		ByteArrayOutputStream baos = new ByteArrayOutputStream();
+			this.serialise(baos, um, rseList);
+			ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
+			this.copyToZip(FileNames.resourceDumpManifest, bais);
+    	}
+    }
+
+
+    private void copyToZip(String entryName, InputStream is)
+            throws IOException
+    {
+        getZos().putNextEntry(new ZipEntry(entryName));
+        byte[] buffer = new byte[102400]; // 100k chunks
+        int len = is.read(buffer);
+        while (len != -1)
+        {
+            getZos().write(buffer, 0, len);
+            len = is.read(buffer);
+        }
+        getZos().closeEntry();
+    }
+
+    @Override
+    protected URL addBitstream(Bitstream bitstream, Item item, List<Collection> collections, ResourceSyncDocument rl)
+    {
+        URL url = super.addBitstream(bitstream, item, collections, rl);
+        String dumppath = this.getPath(item, bitstream, null, false);
+        url.setPath(dumppath);
+
+        // now actually get the bitstream and stick it in the directory
+        try
+        {
+            String entryName = this.getPath(item, bitstream, null, true);
+            InputStream is = bitstream.retrieve();
+            this.copyToZip(entryName, is);
+        }
+        catch (IOException e)
+        {
+        	log.error(e.getMessage(),e);
+//            throw new RuntimeException(e); // FIXME: not so good, probably best to have the method sig support the error
+        }
+        catch (SQLException e)
+        {
+        	log.error(e.getMessage(),e);
+//            throw new RuntimeException(e); // FIXME: not so good, probably best to have the method sig support the error
+        }
+        catch (AuthorizeException e)
+        {
+        	log.error(e.getMessage(),e);
+//            throw new RuntimeException(e); // FIXME: not so good, probably best to have the method sig support the error
+        }
+
+        return url;
+    }
+
+    private String getPath(Item item, Bitstream bitstream, MetadataFormat format, boolean nativeSeparator)
+    {
+        String separator = nativeSeparator ? File.separator : "/";
+        String itempath = item.getHandle().replace("/", "_");
+
+        String filepath;
+        if (bitstream != null)
+        {
+            filepath = Integer.toString(bitstream.getSequenceID()) + "_" + bitstream.getName();
+        }
+        else if (format != null)
+        {
+            filepath = format.getPrefix();
+        }
+        else
+        {
+            throw new RuntimeException("must provide either bitstream or metadata format");
+        }
+        String dumppath = separator + FileNames.dumpResourcesDir + separator + itempath + separator + filepath;
+        return dumppath;
+    }
+
+    @Override
+    protected URL addMetadata(Item item, MetadataFormat format, List<Bitstream> describes, List<Collection> collections, ResourceSyncDocument rl)
+    {
+        URL url = super.addMetadata(item, format, describes, collections, rl);
+        String dumppath = this.getPath(item, null, format, false);
+        url.setPath(dumppath);
+
+        // now actually get the metadata export and stick it in the directory
+        try
+        {
+            String entryName = this.getPath(item, null, format, true);
+            ZipEntry e = new ZipEntry(entryName);
+            getZos().putNextEntry(e);
+
+            // get the dissemination crosswalk for this prefix and get the element for the object
+            MetadataDisseminator.disseminate(item, format.getPrefix(), getZos());
+
+            getZos().closeEntry();
+        }
+        catch (IOException e)
+        {
+        	log.error(e.getMessage(),e);
+//            throw new RuntimeException(e); // FIXME: not so good, probably best to have the method sig support the error
+        }
+        catch (SQLException e)
+        {
+        	log.error(e.getMessage(),e);
+//            throw new RuntimeException(e); // FIXME: not so good, probably best to have the method sig support the error
+        }
+        catch (AuthorizeException e)
+        {
+        	log.error(e.getMessage(),e);
+//            throw new RuntimeException(e); // FIXME: not so good, probably best to have the method sig support the error
+        }
+        catch (CrosswalkException e)
+        {
+        	log.error(e.getMessage(),e);
+//            throw new RuntimeException(e); // FIXME: not so good, probably best to have the method sig support the error
+        }
+
+        return url;
+    }
+}

--- a/src/main/java/org/dspace/resourcesync/DSpaceChangeList.java
+++ b/src/main/java/org/dspace/resourcesync/DSpaceChangeList.java
@@ -1,3 +1,8 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree
+ */
 package org.dspace.resourcesync;
 
 import org.dspace.content.Bitstream;
@@ -22,6 +27,10 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * @author Richard Jones
+ *
+ */
 public class DSpaceChangeList extends DSpaceResourceDocument
 {
     private boolean includeRestricted = false;

--- a/src/main/java/org/dspace/resourcesync/DSpaceChangeListArchive.java
+++ b/src/main/java/org/dspace/resourcesync/DSpaceChangeListArchive.java
@@ -14,9 +14,10 @@ import java.io.OutputStream;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
-
 /**
  * @author Richard Jones
+ * @author Andrea Bollini (andrea.bollini at 4science.it)
+ * @author Andrea Petrucci (andrea.petrucci at 4science.it)
  *
  */
 public class DSpaceChangeListArchive
@@ -26,8 +27,17 @@ public class DSpaceChangeListArchive
     private ChangeListArchive cla = null;
     private UrlManager um;
 
-    public DSpaceChangeListArchive(Context context)
+    public UrlManager getUm() {
+		return um;
+	}
+
+	public void setUm(UrlManager um) {
+		this.um = um;
+	}
+
+	public DSpaceChangeListArchive(Context context)
     {
+
         this.context = context;
         this.um = new UrlManager();
     }

--- a/src/main/java/org/dspace/resourcesync/DSpaceChangeListArchive.java
+++ b/src/main/java/org/dspace/resourcesync/DSpaceChangeListArchive.java
@@ -1,3 +1,8 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree
+ */
 package org.dspace.resourcesync;
 
 import org.dspace.core.Context;
@@ -10,6 +15,10 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
+/**
+ * @author Richard Jones
+ *
+ */
 public class DSpaceChangeListArchive
 {
     private Context context;

--- a/src/main/java/org/dspace/resourcesync/DSpaceResourceDocument.java
+++ b/src/main/java/org/dspace/resourcesync/DSpaceResourceDocument.java
@@ -29,7 +29,6 @@ import java.util.Map;
  */
 public class DSpaceResourceDocument
 {
-    protected List<String> exposeBundles = null;
     protected List<MetadataFormat> mdFormats = null;
     protected Context context;
     protected UrlManager um = new UrlManager();
@@ -39,14 +38,12 @@ public class DSpaceResourceDocument
         this.context = context;
 
         // get all the configuration
-        this.exposeBundles = this.getBundlesToExpose();
         this.mdFormats = this.getMetadataFormats();
     }
 
     public DSpaceResourceDocument(Context context, List<String> exposeBundles, List<MetadataFormat> mdFormats)
     {
         this.context = context;
-        this.exposeBundles = exposeBundles;
         this.mdFormats = mdFormats;
     }
 
@@ -61,21 +58,24 @@ public class DSpaceResourceDocument
         List<Collection> clist = Arrays.asList(collection);
 
         // add all the relevant bitstreams
-        for (Bundle bundle : item.getBundles())
+        boolean isOnlyMetadata = ConfigurationManager.getBooleanProperty("resourcesync", "resourcedump.onlymetadata");
+        if (!isOnlyMetadata)
         {
-            // only expose resources in permitted bundles
-            if (!exposeBundles.contains(bundle.getName()))
-            {
-                continue;
-            }
+        	for (Bundle bundle : item.getBundles())
+        	{
+        		// only expose resources in permitted bundles
+        		if (!ResourceSyncConfiguration.getBundlesToExpose().contains(bundle.getName()))
+        		{
+        			continue;
+        		}
 
-            for (Bitstream bitstream : bundle.getBitstreams())
-            {
-                this.addBitstream(bitstream, item, clist, rl);
-                exposed.add(bitstream);
-            }
+        		for (Bitstream bitstream : bundle.getBitstreams())
+        		{
+        			this.addBitstream(bitstream, item, clist, rl);
+        			exposed.add(bitstream);
+        		}
+        	}
         }
-
         // add all the relevant metadata formats
         for (MetadataFormat format : this.mdFormats)
         {
@@ -87,7 +87,7 @@ public class DSpaceResourceDocument
     {
         URL bs = new URL();
 
-        bs.setLoc(this.getBitstreamUrl(item, bitstream));
+        bs.setLoc(this.getBitstreamUrl(bitstream));
         bs.setLastModified(item.getLastModified()); // last modified date is not available on a bitstream, so we use the item one
         bs.setType(bitstream.getFormat().getMIMEType());
         bs.setLength(bitstream.getSize());
@@ -107,7 +107,8 @@ public class DSpaceResourceDocument
         return bs;
     }
 
-    protected URL addMetadata(Item item, MetadataFormat format, List<Bitstream> describes, List<Collection> collections, ResourceSyncDocument rl)
+    protected URL addMetadata(Item item, MetadataFormat format, List<Bitstream> describes, List<Collection> collections,
+    			ResourceSyncDocument rl)
     {
         URL metadata = new URL();
 
@@ -126,7 +127,7 @@ public class DSpaceResourceDocument
 
         for (Bitstream bs : describes)
         {
-            metadata.addLn(ResourceSync.REL_DESCRIBES, this.getBitstreamUrl(item, bs));
+            metadata.addLn(ResourceSync.REL_DESCRIBES, this.getBitstreamUrl(bs));
         }
 
         for (Collection collection : collections)
@@ -150,25 +151,6 @@ public class DSpaceResourceDocument
         return metadata;
     }
 
-    protected List<String> getBundlesToExpose()
-    {
-        List<String> exposeBundles = new ArrayList<String>();
-        String cfg = ConfigurationManager.getProperty("resourcesync", "expose-bundles");
-        if (cfg == null || "".equals(cfg))
-        {
-            return exposeBundles;
-        }
-
-        String[] bits = cfg.split(",");
-        for (String bundle : bits)
-        {
-            if (!exposeBundles.contains(bundle))
-            {
-                exposeBundles.add(bundle);
-            }
-        }
-        return exposeBundles;
-    }
 
     protected List<MetadataFormat> getMetadataFormats()
     {
@@ -265,27 +247,16 @@ public class DSpaceResourceDocument
         return url;
     }
 
-    protected String getBitstreamUrl(Item item, Bitstream bitstream)
-    {
-        String handle = item.getHandle();
-        String bsLink = ConfigurationManager.getProperty("dspace.url");
-
-        if (handle != null && !"".equals(handle))
-        {
-            bsLink = bsLink + "/bitstream/" + handle + "/" + bitstream.getSequenceID() + "/" + bitstream.getName();
-        }
-        else
-        {
-            bsLink = bsLink + "/retrieve/" + bitstream.getID() + "/" + bitstream.getName();
-        }
-
-        return bsLink;
-    }
+	protected String getBitstreamUrl(Bitstream bitstream) {
+		String bsLink = ConfigurationManager.getProperty("resourcesync", "base-url");
+		bsLink += "/bitstreams/" + bitstream.getID();
+		return bsLink;
+	}
 
     protected String getCollectionUrl(Collection collection)
     {
         String handle = collection.getHandle();
         String base = ConfigurationManager.getProperty("dspace.url");
-        return base + "/" + handle;
+        return base + "/handle/" + handle;
     }
 }

--- a/src/main/java/org/dspace/resourcesync/DSpaceResourceDocument.java
+++ b/src/main/java/org/dspace/resourcesync/DSpaceResourceDocument.java
@@ -1,3 +1,8 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree
+ */
 package org.dspace.resourcesync;
 
 import org.dspace.content.Bitstream;
@@ -18,6 +23,10 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * @author Richard Jones
+ *
+ */
 public class DSpaceResourceDocument
 {
     protected List<String> exposeBundles = null;

--- a/src/main/java/org/dspace/resourcesync/DSpaceResourceDump.java
+++ b/src/main/java/org/dspace/resourcesync/DSpaceResourceDump.java
@@ -1,3 +1,8 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree
+ */
 package org.dspace.resourcesync;
 
 import org.dspace.authorize.AuthorizeException;
@@ -29,6 +34,10 @@ import java.util.List;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
+/**
+ * @author Richard Jones
+ *
+ */
 public class DSpaceResourceDump extends DSpaceResourceDocument
 {
     protected String metadataChangeFreq = null;

--- a/src/main/java/org/dspace/resourcesync/DSpaceResourceDumpZip.java
+++ b/src/main/java/org/dspace/resourcesync/DSpaceResourceDumpZip.java
@@ -5,21 +5,18 @@
  */
 package org.dspace.resourcesync;
 
+import org.apache.log4j.Logger;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.content.Bitstream;
 import org.dspace.content.Collection;
 import org.dspace.content.Item;
 import org.dspace.content.crosswalk.CrosswalkException;
-import org.dspace.content.crosswalk.DisseminationCrosswalk;
 import org.dspace.core.Context;
-import org.dspace.core.PluginManager;
-import org.jdom.Document;
-import org.jdom.Element;
-import org.jdom.output.Format;
-import org.jdom.output.XMLOutputter;
 import org.openarchives.resourcesync.ResourceSyncDocument;
 import org.openarchives.resourcesync.URL;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -31,153 +28,158 @@ import java.sql.SQLException;
 import java.util.List;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
-
 /**
  * @author Richard Jones
- *
+ * @author Andrea Bollini (andrea.bollini at 4science.it)
+ * @author Andrea Petrucci (andrea.petrucci at 4science.it)
  */
-public class DSpaceResourceDumpZip extends DSpaceResourceList
-{
-    private String dumpDir;
-    private ZipOutputStream zos;
+public class DSpaceResourceDumpZip extends DSpaceResourceList {
+	private String dumpDir;
+	private ZipOutputStream zos;
+	private ZipOutputStream zosOnTheFly;
+	boolean isOnTheFly = false;
+	private OutputStream baos;
+    private static Logger log = Logger.getLogger(DSpaceResourceDumpZip.class);
 
-    public DSpaceResourceDumpZip(Context context, String dumpDir)
-    {
-        super(context, true);
-        this.dumpDir = dumpDir;
-        try
-        {
-            this.zos = new ZipOutputStream(new FileOutputStream(this.dumpDir + File.separator + FileNames.resourceDumpZip));
-        }
-        catch (FileNotFoundException e)
-        {
-            throw new RuntimeException(e);
-        }
-    }
+	public DSpaceResourceDumpZip(Context context, String dumpDir) {
+		super(context, true);
+		this.dumpDir = dumpDir;
+		this.isOnTheFly = false;
+	}
 
-    public void serialise()
-            throws SQLException, IOException
-    {
-        // first generate the manifest file.  This uses the other overrides in this object
-        // to also copy in the bitstreams and metadata serialisations which are relevant
-        // everything will be added to the zip
-        String drlFile = this.dumpDir + File.separator + FileNames.resourceDumpManifest;
-        FileOutputStream fos = new FileOutputStream(new File(drlFile));
-        this.serialise(fos);
+	public DSpaceResourceDumpZip(Context context,OutputStream os) {
+		super(context, true);
+		this.isOnTheFly = true;
+		this.baos = os;
+	}
 
-        // incorporate the manifest into the zip
-        File manifest = new File(drlFile);
-        FileInputStream is = new FileInputStream(manifest);
+	public ZipOutputStream getZos() {
+		if (isOnTheFly) {
+			if (this.zosOnTheFly == null) {
+				zosOnTheFly = new ZipOutputStream(baos);
+			}
+			return zosOnTheFly;
+		} else {
+			if (this.zos == null) {
+				try {
+					this.zos = new ZipOutputStream(
+							new FileOutputStream(this.dumpDir + File.separator + FileNames.resourceDumpZip));
+				} catch (FileNotFoundException e) {
+					log.error(e.getMessage(),e);				}
+			}
+			return zos;
+		}
+	}
+	
 
-        this.copyToZip(FileNames.resourceDumpManifest, is);
-        this.zos.close();
+	public void serialise(String handle, UrlManager um) throws SQLException, IOException {
+		// first generate the manifest file. This uses the other overrides in this
+		// object
+		// to also copy in the bitstreams and metadata serialisations which are relevant
+		// everything will be added to the zip
+		if (!isOnTheFly) {
+			String drlFile = FileNames.resourceDumpManifest;
+			FileOutputStream fos = new FileOutputStream(new File(drlFile));
+			this.serialise(fos, handle, um);
 
-        // get rid of the left over manifest file
-        manifest.delete();
-    }
+			// incorporate the manifest into the zip
+			File manifest = new File(drlFile);
+			FileInputStream is = new FileInputStream(manifest);
+			
+			this.copyToZip(FileNames.resourceDumpManifest, is);
 
-    private void copyToZip(String entryName, InputStream is)
-            throws IOException
-    {
-        this.zos.putNextEntry(new ZipEntry(entryName));
-        byte[] buffer = new byte[102400]; // 100k chunks
-        int len = is.read(buffer);
-        while (len != -1)
-        {
-            this.zos.write(buffer, 0, len);
-            len = is.read(buffer);
-        }
-        this.zos.closeEntry();
-    }
+			getZos().close();
 
-    @Override
-    protected URL addBitstream(Bitstream bitstream, Item item, List<Collection> collections, ResourceSyncDocument rl)
-    {
-        URL url = super.addBitstream(bitstream, item, collections, rl);
-        String dumppath = this.getPath(item, bitstream, null, false);
-        url.setPath(dumppath);
+			// get rid of the left over manifest file
+			manifest.delete();
+		}
+		else {
+			ByteArrayOutputStream baos = new ByteArrayOutputStream();
+			this.serialise(baos, handle, um);
+			ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
+			this.copyToZip(FileNames.resourceDumpManifest, bais);
+		}
 
-        // now actually get the bitstream and stick it in the directory
-        try
-        {
-            String entryName = this.getPath(item, bitstream, null, true);
-            InputStream is = bitstream.retrieve();
-            this.copyToZip(entryName, is);
-        }
-        catch (IOException e)
-        {
-            throw new RuntimeException(e); // FIXME: not so good, probably best to have the method sig support the error
-        }
-        catch (SQLException e)
-        {
-            throw new RuntimeException(e); // FIXME: not so good, probably best to have the method sig support the error
-        }
-        catch (AuthorizeException e)
-        {
-            throw new RuntimeException(e); // FIXME: not so good, probably best to have the method sig support the error
-        }
 
-        return url;
-    }
+	}
 
-    private String getPath(Item item, Bitstream bitstream, MetadataFormat format, boolean nativeSeparator)
-    {
-        String separator = nativeSeparator ? File.separator : "/";
-        String itempath = item.getHandle().replace("/", "_");
+	private void copyToZip(String entryName, InputStream is) throws IOException {
+		getZos().putNextEntry(new ZipEntry(entryName));
+		byte[] buffer = new byte[102400]; // 100k chunks
+		int len = is.read(buffer);
+		while (len != -1) {
+			getZos().write(buffer, 0, len);
+			len = is.read(buffer);
+		}
+		getZos().closeEntry();
+	}
 
-        String filepath;
-        if (bitstream != null)
-        {
-            filepath = Integer.toString(bitstream.getSequenceID()) + "_" + bitstream.getName();
-        }
-        else if (format != null)
-        {
-            filepath = format.getPrefix();
-        }
-        else
-        {
-            throw new RuntimeException("must provide either bitstream or metadata format");
-        }
-        String dumppath = separator + FileNames.dumpResourcesDir + separator + itempath + separator + filepath;
-        return dumppath;
-    }
+	@Override
+	protected URL addBitstream(Bitstream bitstream, Item item, List<Collection> collections, ResourceSyncDocument rl) {
+		URL url = super.addBitstream(bitstream, item, collections, rl);
+		String dumppath = this.getPath(item, bitstream, null, false);
+		url.setPath(dumppath);
 
-    @Override
-    protected URL addMetadata(Item item, MetadataFormat format, List<Bitstream> describes, List<Collection> collections, ResourceSyncDocument rl)
-    {
-        URL url = super.addMetadata(item, format, describes, collections, rl);
-        String dumppath = this.getPath(item, null, format, false);
-        url.setPath(dumppath);
+		// now actually get the bitstream and stick it in the directory
+		try {
+			String entryName = this.getPath(item, bitstream, null, true);
+			InputStream is = bitstream.retrieve();
+			this.copyToZip(entryName, is);
+		} catch (IOException e) {
+			log.error(e.getMessage(),e);				
+		} catch (SQLException e) {
+			log.error(e.getMessage(),e);				
+		} catch (AuthorizeException e) {
+			log.error(e.getMessage(),e);				
+		}
 
-        // now actually get the metadata export and stick it in the directory
-        try
-        {
-            String entryName = this.getPath(item, null, format, true);
-            ZipEntry e = new ZipEntry(entryName);
-            this.zos.putNextEntry(e);
+		return url;
+	}
 
-            // get the dissemination crosswalk for this prefix and get the element for the object
-            MetadataDisseminator.disseminate(item, format.getPrefix(), this.zos);
+	private String getPath(Item item, Bitstream bitstream, MetadataFormat format, boolean nativeSeparator) {
+		String separator = nativeSeparator ? File.separator : "/";
+		String itempath = item.getHandle().replace("/", "_");
 
-            this.zos.closeEntry();
-        }
-        catch (IOException e)
-        {
-            throw new RuntimeException(e); // FIXME: not so good, probably best to have the method sig support the error
-        }
-        catch (SQLException e)
-        {
-            throw new RuntimeException(e); // FIXME: not so good, probably best to have the method sig support the error
-        }
-        catch (AuthorizeException e)
-        {
-            throw new RuntimeException(e); // FIXME: not so good, probably best to have the method sig support the error
-        }
-        catch (CrosswalkException e)
-        {
-            throw new RuntimeException(e); // FIXME: not so good, probably best to have the method sig support the error
-        }
+		String filepath;
+		if (bitstream != null) {
+			filepath = Integer.toString(bitstream.getSequenceID()) + "_" + bitstream.getName();
+		} else if (format != null) {
+			filepath = format.getPrefix();
+		} else {
+			throw new RuntimeException("must provide either bitstream or metadata format");
+		}
+		String dumppath = separator + FileNames.dumpResourcesDir + separator + itempath + separator + filepath;
+		return dumppath;
+	}
 
-        return url;
-    }
+	@Override
+	protected URL addMetadata(Item item, MetadataFormat format, List<Bitstream> describes, List<Collection> collections,
+			ResourceSyncDocument rl) {
+		URL url = super.addMetadata(item, format, describes, collections, rl);
+		String dumppath = this.getPath(item, null, format, false);
+		url.setPath(dumppath);
+
+		// now actually get the metadata export and stick it in the directory
+		try {
+			String entryName = this.getPath(item, null, format, true);
+			ZipEntry e = new ZipEntry(entryName);
+			getZos().putNextEntry(e);
+
+			// get the dissemination crosswalk for this prefix and get the element for the
+			// object
+			MetadataDisseminator.disseminate(item, format.getPrefix(), getZos());
+
+			getZos().closeEntry();
+		} catch (IOException e) {
+			log.error(e.getMessage(),e);				
+		} catch (SQLException e) {
+			log.error(e.getMessage(),e);				
+		} catch (AuthorizeException e) {
+			log.error(e.getMessage(),e);				
+		} catch (CrosswalkException e) {
+			log.error(e.getMessage(),e);				
+		}
+
+		return url;
+	}
 }

--- a/src/main/java/org/dspace/resourcesync/DSpaceResourceDumpZip.java
+++ b/src/main/java/org/dspace/resourcesync/DSpaceResourceDumpZip.java
@@ -1,3 +1,8 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree
+ */
 package org.dspace.resourcesync;
 
 import org.dspace.authorize.AuthorizeException;
@@ -27,6 +32,10 @@ import java.util.List;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
+/**
+ * @author Richard Jones
+ *
+ */
 public class DSpaceResourceDumpZip extends DSpaceResourceList
 {
     private String dumpDir;

--- a/src/main/java/org/dspace/resourcesync/DSpaceResourceList.java
+++ b/src/main/java/org/dspace/resourcesync/DSpaceResourceList.java
@@ -1,3 +1,8 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree
+ */
 package org.dspace.resourcesync;
 
 import org.dspace.content.Bitstream;
@@ -16,6 +21,10 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * @author Richard Jones
+ *
+ */
 public class DSpaceResourceList extends DSpaceResourceDocument
 {
     protected String metadataChangeFreq = null;

--- a/src/main/java/org/dspace/resourcesync/FileNames.java
+++ b/src/main/java/org/dspace/resourcesync/FileNames.java
@@ -1,7 +1,16 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree
+ */
 package org.dspace.resourcesync;
 
 import java.io.File;
 
+/**
+ * @author Richard Jones
+ *
+ */
 public class FileNames
 {
     public static String resourceSyncDocument = "resourcesync.xml";

--- a/src/main/java/org/dspace/resourcesync/FileNames.java
+++ b/src/main/java/org/dspace/resourcesync/FileNames.java
@@ -13,25 +13,36 @@ import java.io.File;
  */
 public class FileNames
 {
-    public static String resourceSyncDocument = "resourcesync.xml";
+    public static String resourceSyncDocument = "sourcedescription.xml";
+    public static String resourceSyncDocumentIndex = "sourcedescriptionindex.xml";
     public static String resourceList = "resourcelist.xml";
     public static String resourceDumpZip = "resourcedump.zip";
     public static String resourceDump = "resourcedump.xml";
     public static String capabilityList = "capabilitylist.xml";
-    public static String changeListArchive = "changelistarchive.xml";
     public static String resourceDumpManifest = "manifest.xml";
+    public static String changeDumpZip = "changedump.zip";
+    public static String changeDumpManifest = "manifest.xml";
+    public static String changeListArchive = "changelistindex.xml";
     public static String dumpResourcesDir = "resources";
-
+    
     public static String changeList(String dateString)
     {
         return "changelist_" + dateString + ".xml";
-    }
 
+    }
+    public static String changeDump(String dateString)
+    {
+        return "changedump_" + dateString + ".zip";
+
+    }
     public static boolean isChangeList(File file)
     {
         return file.getName().startsWith("changelist_");
     }
-
+    public static boolean isChangeDump(File file)
+    {
+        return file.getName().startsWith("changedump_");
+    }
     public static String changeListDate(File file)
     {
         return FileNames.changeListDate(file.getName());
@@ -41,6 +52,18 @@ public class FileNames
     {
         int start = "changelist_".length(); // 11
         int end = filename.length() - ".xml".length();
+        String dr = filename.substring(start, end);
+        return dr;
+    }
+    public static String changeDumpDate(File file)
+    {
+        return FileNames.changeDumpDate(file.getName());
+    }
+
+    public static String changeDumpDate(String filename)
+    {
+        int start = "changedump_".length(); // 11
+        int end = filename.length() - ".zip".length();
         String dr = filename.substring(start, end);
         return dr;
     }

--- a/src/main/java/org/dspace/resourcesync/MetadataDisseminator.java
+++ b/src/main/java/org/dspace/resourcesync/MetadataDisseminator.java
@@ -1,3 +1,8 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree
+ */
 package org.dspace.resourcesync;
 
 import org.dspace.authorize.AuthorizeException;
@@ -14,6 +19,10 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.sql.SQLException;
 
+/**
+ * @author Richard Jones
+ *
+ */
 public class MetadataDisseminator
 {
     public static void disseminate(Item item, String formatPrefix, OutputStream os)

--- a/src/main/java/org/dspace/resourcesync/MetadataFormat.java
+++ b/src/main/java/org/dspace/resourcesync/MetadataFormat.java
@@ -1,5 +1,14 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree
+ */
 package org.dspace.resourcesync;
 
+/**
+ * @author Richard Jones
+ *
+ */
 public class MetadataFormat
 {
     private String prefix;

--- a/src/main/java/org/dspace/resourcesync/ResourceSyncAuditService.java
+++ b/src/main/java/org/dspace/resourcesync/ResourceSyncAuditService.java
@@ -1,0 +1,159 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree
+ */
+package org.dspace.resourcesync;
+/**
+ * @author Andrea Bollini (andrea.bollini at 4science.it)
+ * @author Andrea Petrucci (andrea.petrucci at 4science.it)
+ */
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.Iterator;
+import java.util.List;
+
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
+import org.apache.solr.client.solrj.SolrQuery;
+import org.apache.solr.client.solrj.SolrQuery.ORDER;
+import org.apache.solr.client.solrj.SolrQuery.SortClause;
+import org.apache.solr.client.solrj.SolrServerException;
+import org.apache.solr.client.solrj.impl.HttpSolrServer;
+import org.apache.solr.client.solrj.response.QueryResponse;
+import org.apache.solr.common.SolrDocument;
+import org.apache.solr.common.SolrInputDocument;
+import org.apache.solr.common.util.DateUtil;
+import org.dspace.utils.DSpace;
+
+/**
+ * Service to interact with the Solr resourcesync core
+ * 
+ */
+public class ResourceSyncAuditService {
+	private static final String RESOURCE_ID_FIELD = "resource_id";
+
+	private static final String RESOURCE_TYPE_FIELD = "resource_type";
+
+	private static final String CHANGETYPE_FIELD = "changetype";
+
+	private static final String DATETIME_FIELD = "datetime";
+
+	private static final String SCOPES_FIELD = "scopes";
+	
+	private static final String HANDLE_FIELD = "handle";
+	
+	private static final String EXTRA_FIELD = "extra";
+
+	// ENUM con i valori di type
+	// Install|Modify_Metadata|Delete|Add|Remove
+	public static enum ChangeType {
+		CREATE("create"), REMOVE("remove"), UPDATE("update");
+		private final String type;
+
+		ChangeType(String type) {
+			this.type = type;
+		}
+
+		public String type() {
+			return type;
+		}
+	}
+
+	private Logger log = LogManager.getLogger(ResourceSyncAuditService.class);
+
+	/**
+	 * Non-Static CommonsHttpSolrServer for processing indexing events.
+	 */
+	private HttpSolrServer solr = null;
+
+	protected HttpSolrServer getSolr() {
+		if (solr == null) {
+			String solrService = new DSpace().getConfigurationService().getProperty("resourcesync.solr.server");
+
+			try {
+				log.debug("Solr URL: " + solrService);
+				solr = new HttpSolrServer(solrService);
+
+				solr.setBaseURL(solrService);
+				solr.setUseMultiPartPost(true);
+				SolrQuery solrQuery = new SolrQuery().setQuery("*:*");
+				solrQuery.setFields(RESOURCE_ID_FIELD, RESOURCE_TYPE_FIELD, CHANGETYPE_FIELD, DATETIME_FIELD,
+						SCOPES_FIELD);
+				solrQuery.setRows(1);
+				solr.query(solrQuery);
+			} catch (SolrServerException e) {
+				log.error("Error while initializing solr server", e);
+			}
+		}
+		return solr;
+	}
+
+	public void addEvent(int resourceID, int resourcetype, ChangeType eventtype, Date date, List<String> scopes,String handle,String[] identifiers) {
+		SolrInputDocument solrInDoc = new SolrInputDocument();
+		solrInDoc.addField(RESOURCE_ID_FIELD, resourceID);
+		solrInDoc.addField(RESOURCE_TYPE_FIELD, resourcetype);
+		solrInDoc.addField(CHANGETYPE_FIELD, eventtype);
+		solrInDoc.addField(DATETIME_FIELD, date);
+		solrInDoc.addField(SCOPES_FIELD, scopes);
+		solrInDoc.addField(HANDLE_FIELD, handle);
+		solrInDoc.addField(EXTRA_FIELD, identifiers);
+		try {
+			getSolr().add(solrInDoc);
+		} catch (SolrServerException | IOException e) {
+			log.error(e.getMessage(), e);
+		}
+	}
+
+	public List<ResourceSyncEvent> listEvents(Date from, Date to, String scope) {
+//		SolrQuery solrQuery = new SolrQuery(buildTimeQuery(from, to));
+		SolrQuery solrQuery = new SolrQuery((buildTimeQuery(from, to)));
+		solrQuery.setRows(Integer.MAX_VALUE);
+		solrQuery.addSort(new SortClause(DATETIME_FIELD, ORDER.asc));
+		solrQuery.addFilterQuery(SCOPES_FIELD+":" + scope);
+//		solrQuery.addFilterQuery("scope:" + scope);
+
+		QueryResponse queryResponse;
+		try {
+			queryResponse = getSolr().query(solrQuery);
+		} catch (SolrServerException e) {
+			throw new RuntimeException(e.getMessage(), e);
+		}
+		List<ResourceSyncEvent> listResourceSyncEvent = new ArrayList<ResourceSyncEvent>();
+		// queryResponse.getResults().iterator().next().get(RESOURCE_ID_FIELD);
+		Iterator<SolrDocument> iterator = queryResponse.getResults().iterator();
+		while (iterator.hasNext()) {
+			ResourceSyncEvent rse = new ResourceSyncEvent();
+			SolrDocument sd = iterator.next();
+			rse.setResource_id((int) sd.getFieldValue(RESOURCE_ID_FIELD));
+			rse.setResource_type((int) sd.getFieldValue(RESOURCE_TYPE_FIELD));
+			rse.setChangetype((String) sd.getFieldValue(CHANGETYPE_FIELD));
+			rse.setDatetime((Date) sd.getFieldValue(DATETIME_FIELD));
+			rse.setScopes((List<String>) sd.getFieldValue(SCOPES_FIELD));
+			rse.setHandle((String)sd.getFieldValue(HANDLE_FIELD));
+			rse.setScopes((List<String>) sd.getFieldValue(EXTRA_FIELD));
+//			System.out.println("+++Resource id = "+rse.getResource_id()+" Resource Type = "+
+//					rse.getResource_type()+" changeType = "+rse.getChangetype()+ " datetime = "+rse.getDatetime()+
+//						" scopes = "+rse.getScopes());
+			listResourceSyncEvent.add(rse);
+		}
+		return listResourceSyncEvent;
+	}
+
+	private String buildTimeQuery(Date from, Date to) {
+		String fromDate;
+		if (from == null) {
+			fromDate = "*";
+		} else {
+			fromDate = DateUtil.getThreadLocalDateFormat().format(from);
+		}
+		String toDate;
+		if (to == null) {
+			toDate = "*";
+		} else {
+			toDate = DateUtil.getThreadLocalDateFormat().format(to);
+		}
+		return DATETIME_FIELD + ":[" + fromDate + " TO " + toDate + "]";
+	}
+}

--- a/src/main/java/org/dspace/resourcesync/ResourceSyncConfiguration.java
+++ b/src/main/java/org/dspace/resourcesync/ResourceSyncConfiguration.java
@@ -1,0 +1,43 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree
+ */
+package org.dspace.resourcesync;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.dspace.core.ConfigurationManager;
+/**
+ * @author Andrea Bollini (andrea.bollini at 4science.it)
+ * @author Andrea Petrucci (andrea.petrucci at 4science.it)
+ */
+public class ResourceSyncConfiguration {
+	
+	private static List<String> exposeBundles = null;
+	
+	public static List<String> getBundlesToExpose()
+    {
+		if (exposeBundles != null) {
+			return exposeBundles;
+		}
+		
+		exposeBundles = new ArrayList<String>();
+        String cfg = ConfigurationManager.getProperty("resourcesync", "expose-bundles");
+        if (cfg == null || "".equals(cfg))
+        {
+            return exposeBundles;
+        }
+
+        String[] bits = cfg.split(",");
+        for (String bundle : bits)
+        {
+            if (!exposeBundles.contains(bundle))
+            {
+                exposeBundles.add(bundle);
+            }
+        }
+        return exposeBundles;
+    }
+}

--- a/src/main/java/org/dspace/resourcesync/ResourceSyncConsumer.java
+++ b/src/main/java/org/dspace/resourcesync/ResourceSyncConsumer.java
@@ -1,0 +1,262 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree
+ */
+package org.dspace.resourcesync;
+
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+import org.apache.log4j.Logger;
+import org.dspace.content.Bitstream;
+import org.dspace.content.Bundle;
+import org.dspace.content.Collection;
+import org.dspace.content.Community;
+import org.dspace.content.DSpaceObject;
+import org.dspace.content.Item;
+import org.dspace.content.Site;
+import org.dspace.core.Constants;
+import org.dspace.core.Context;
+import org.dspace.event.Consumer;
+import org.dspace.event.Event;
+import org.dspace.resourcesync.ResourceSyncAuditService.ChangeType;
+import org.dspace.utils.DSpace;
+
+/**
+ * Class for audit changes relevant for resourcesync.
+ * 
+ * @version $Revision$
+ *
+ * @author Andrea Bollini (andrea.bollini at 4science.it)
+ * @author Andrea Petrucci (andrea.petrucci at 4science.it)
+ */
+ 
+public class ResourceSyncConsumer implements Consumer {
+	/** log4j logger */
+	private static Logger log = Logger.getLogger(ResourceSyncConsumer.class);
+
+	private ResourceSyncAuditService resourceSyncAuditService;
+
+
+	public void initialize() throws Exception {
+		resourceSyncAuditService = new DSpace().getServiceManager()
+				.getServiceByName(ResourceSyncAuditService.class.getCanonicalName(), ResourceSyncAuditService.class);
+	}
+
+	/**
+	 * Consume a content event -- just build the sets of objects to add (new) to the
+	 * index, update, and delete.
+	 * 
+	 * @param ctx
+	 *            DSpace context
+	 * @param event
+	 *            Content event
+	 */
+	public void consume(Context ctx, Event event) throws Exception {
+
+		int st = event.getSubjectType();
+
+		DSpaceObject subject = event.getSubject(ctx);
+//		DSpaceObject object = event.getObject(ctx);
+
+		// If event subject is a Bundle and event was Add or Remove,
+		// transform the event to be a Modify on the owning Item.
+		// It could be a new bitstream in the TEXT bundle which
+		// would change the index.
+//		int et = event.getEventType();
+
+		switch (st) {
+		case Constants.ITEM:
+			consumeItemEvent(ctx, (Item) subject, event);
+			break;
+
+		case Constants.BUNDLE:
+			consumeBundleEvent(ctx, (Bundle) subject, event);
+			break;
+
+		case Constants.BITSTREAM:
+			consumeBistreamEvent(event);
+			break;
+
+		case Constants.COLLECTION:
+			consumeCollectionEvent((Collection) subject, event);
+			break;
+
+		default:
+			log.warn("ResourceSyncConsumer should not have been given this kind of Subject in an event, skipping: "
+					+ event.toString());
+			return;
+
+		}
+	}
+
+	public void end(Context ctx) throws Exception {
+		// No-op
+	}
+
+	public void finish(Context ctx) throws Exception {
+		// No-op
+
+	}
+
+	private void consumeCollectionEvent(Collection collection, Event event) {
+		int et = event.getEventType();
+		int itemID = event.getObjectID();
+
+		if (et != Event.ADD && et != Event.REMOVE) {
+			return;
+		}
+
+		List<String> scopes = new ArrayList<String>();
+		Community[] community = null;
+		switch (et) {
+		case Event.ADD:
+			try {
+				community = collection.getCommunities();
+			} catch (SQLException e) {
+	        	log.error(e.getMessage(),e);
+			}
+			for (Community c : community) {
+				scopes.add(c.getHandle());
+			}
+			scopes.add(collection.getHandle());
+			addCreateEvent(Constants.ITEM, itemID, scopes,event.getDetail(),event.getIdentifiers());
+			break;
+		case Event.REMOVE:
+			try {
+				community = collection.getCommunities();
+			} catch (SQLException e) {
+	        	log.error(e.getMessage(),e);
+			}
+			for (Community c : community) {
+				scopes.add(c.getHandle());
+			}
+			scopes.add(collection.getHandle());
+			addRemoveEvent(Constants.ITEM, itemID, scopes,event.getDetail(),event.getIdentifiers());
+			break;
+		}
+	}
+
+	private void consumeBistreamEvent(Event event) {
+		int et = event.getEventType();
+		int bitstreamID = event.getSubjectID();
+
+		if (et != Event.DELETE) {
+			return;
+		}
+		List<String> scopes = new ArrayList<String>();
+		scopes.add(Site.getSiteHandle());
+		addRemoveEvent(Constants.BITSTREAM, bitstreamID, scopes,event.getDetail(),event.getIdentifiers());
+	}
+
+	private void consumeItemEvent(Context context, Item item, Event event) throws SQLException {
+		int et = event.getEventType();
+		int itemID = event.getSubjectID();
+		Bundle bnd = (Bundle) event.getObject(context);
+
+		if (et != Event.ADD && et != Event.REMOVE && et != Event.INSTALL && et != Event.MODIFY_METADATA
+				&& et != Event.DELETE) {
+			return;
+		}
+
+		List<String> scopes = new ArrayList<String>();
+		switch (et) {
+		case Event.INSTALL:
+			scopes.add(Site.getSiteHandle());
+			addCreateEvent(Constants.ITEM, itemID, scopes,event.getDetail(),event.getIdentifiers());
+			break;
+		case Event.MODIFY_METADATA:
+			addUpdateEvent(Constants.ITEM, itemID, getScopes(item),event.getDetail(),event.getIdentifiers());
+			break;
+		case Event.ADD:
+
+			if (isResourceSyncRelevant(bnd)) {
+				for (Bitstream b : bnd.getBitstreams()) {
+					addCreateEvent(Constants.BITSTREAM, b.getID(), getScopes(item),event.getDetail(),event.getIdentifiers());
+				}
+			}
+			break;
+		case Event.REMOVE:
+			if (isResourceSyncRelevant(bnd)) {
+				for (Bitstream b : bnd.getBitstreams()) {
+					addRemoveEvent(Constants.BITSTREAM, b.getID(), getScopes(item),event.getDetail(),event.getIdentifiers());
+				}
+			}
+			break;
+		case Event.DELETE:
+			scopes.add(Site.getSiteHandle());
+			addRemoveEvent(Constants.ITEM, itemID, scopes,event.getDetail(),event.getIdentifiers());
+			break;
+		}
+	}
+
+	private boolean isResourceSyncRelevant(Bundle bnd) {
+		if (bnd == null)
+			return false;
+		return ResourceSyncConfiguration.getBundlesToExpose().contains(bnd.getName());
+	}
+
+	private void consumeBundleEvent(Context context, Bundle bundle, Event event) throws SQLException {
+		int et = event.getEventType();
+
+		if (et != Event.ADD && et != Event.REMOVE) {
+			return;
+		}
+
+		// if the bundle doesn't exist anymore we will deal with the REMOVE at the ITEM
+		// level
+		if (bundle == null) {
+			return;
+		}
+
+		if (!isResourceSyncRelevant(bundle)) {
+			return;
+		}
+
+		Item item = (Item) bundle.getParentObject();
+
+		int bitID = event.getObjectID();
+		List<String> scopes = getScopes(item);
+		switch (et) {
+		case Event.ADD:
+			addCreateEvent(Constants.BITSTREAM, bitID, scopes,event.getDetail(),event.getIdentifiers());
+			break;
+		case Event.REMOVE:
+			addRemoveEvent(Constants.BITSTREAM, bitID, scopes,event.getDetail(),event.getIdentifiers());
+			break;
+		}
+	}
+
+	private void addCreateEvent(int resourcetype, int resourceID, List<String> scopes,String handle, String[] identifiers) {
+		addEvent(resourcetype, resourceID, ChangeType.CREATE, scopes,handle,identifiers);
+	}
+
+	private void addUpdateEvent(int resourcetype, int resourceID, List<String> scopes,String handle, String[] identifiers) {
+		addEvent(resourcetype, resourceID, ChangeType.UPDATE, scopes,handle,identifiers);
+
+	}
+
+	private void addRemoveEvent(int resourcetype, int resourceID, List<String> scopes,String handle, String[] identifiers) {
+		addEvent(resourcetype, resourceID, ChangeType.REMOVE, scopes,handle,identifiers);
+	}
+
+	private void addEvent(int resourcetype, int resourceID, ChangeType eventtype, List<String> scopes,String handle, String[] identifiers) {
+		resourceSyncAuditService.addEvent(resourceID, resourcetype, eventtype, new Date(), scopes,handle,identifiers);
+	}
+
+	private List<String> getScopes(Item item) throws SQLException {
+		List<String> scopes = new ArrayList<String>();
+		for (Collection c : item.getCollections()) {
+			scopes.add(c.getHandle());
+		}
+		for (Community c : item.getCommunities()) {
+			scopes.add(c.getHandle());
+		}
+		scopes.add(Site.getSiteHandle());
+		return scopes;
+	}
+
+}

--- a/src/main/java/org/dspace/resourcesync/ResourceSyncEvent.java
+++ b/src/main/java/org/dspace/resourcesync/ResourceSyncEvent.java
@@ -1,0 +1,65 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree
+ */
+package org.dspace.resourcesync;
+
+import java.util.Date;
+import java.util.List;
+/**
+ * @author Andrea Bollini (andrea.bollini at 4science.it)
+ * @author Andrea Petrucci (andrea.petrucci at 4science.it)
+ */
+public class ResourceSyncEvent {
+	private int resource_id;
+	private int resource_type;
+	private String changetype;
+	private Date datetime;
+	private List<String> scopes;
+	private String handle;
+	private List<String> extra;
+	public List<String> getExtra() {
+		return extra;
+	}
+	public void setExtra(List<String> extra) {
+		this.extra = extra;
+	}
+	public String getHandle() {
+		return handle;
+	}
+	public void setHandle(String handle) {
+		this.handle = handle;
+	}
+	public int getResource_id() {
+		return resource_id;
+	}
+	public void setResource_id(int resource_id) {
+		this.resource_id = resource_id;
+	}
+	public int getResource_type() {
+		return resource_type;
+	}
+	public void setResource_type(int resource_type) {
+		this.resource_type = resource_type;
+	}
+	public String getChangetype() {
+		return changetype;
+	}
+	public void setChangetype(String changetype) {
+		this.changetype = changetype;
+	}
+	public Date getDatetime() {
+		return datetime;
+	}
+	public void setDatetime(Date datetime) {
+		this.datetime = datetime;
+	}
+	public List<String> getScopes() {
+		return scopes;
+	}
+	public void setScopes(List<String> scopes) {
+		this.scopes = scopes;
+	}
+
+}

--- a/src/main/java/org/dspace/resourcesync/ResourceSyncGenerator.java
+++ b/src/main/java/org/dspace/resourcesync/ResourceSyncGenerator.java
@@ -10,410 +10,655 @@ import org.apache.commons.cli.CommandLineParser;
 import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.PosixParser;
+import org.dspace.content.Collection;
+import org.dspace.content.Community;
+import org.dspace.content.DSpaceObject;
+import org.dspace.content.Site;
 import org.dspace.core.ConfigurationManager;
+import org.dspace.core.Constants;
 import org.dspace.core.Context;
+import org.dspace.handle.HandleManager;
+import org.openarchives.resourcesync.ResourceSync;
 import org.openarchives.resourcesync.ResourceSyncDescription;
+import org.openarchives.resourcesync.ResourceSyncDescriptionIndex;
+import org.apache.log4j.Logger;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.sql.SQLException;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.util.ArrayList;
 import java.util.Date;
-
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 /**
  * @author Richard Jones
- *
+ * @author Andrea Bollini (andrea.bollini at 4science.it)
+ * @author Andrea Petrucci (andrea.petrucci at 4science.it)
  */
 public class ResourceSyncGenerator
 {
-    public static void main(String[] args)
-            throws Exception
-    {
-        Options options = new Options();
-        options.addOption("i", "init", false, "Create a fresh ResourceSync description of this repository - this will remove any previous ResourceSync documents");
-        options.addOption("u", "update", false, "Update the Change List ResourceSync document with the changes since this script last ran");
-        options.addOption("r", "rebase", false, "Update the Resource List ResourceSync document to reflect the current state of the archive, and bring the Change List up to the same level");
-        CommandLineParser parser = new PosixParser();
-        CommandLine cmd = parser.parse( options, args);
+	private static Logger log = Logger.getLogger(ResourceSyncGenerator.class);
+	public static void main(String[] args)
+			throws Exception
+	{
+		Options options = new Options();
+		options.addOption("i", "init", false, "Create a fresh ResourceSync description of this repository - this will remove any previous ResourceSync documents");
+		options.addOption("u", "update", false, "Update the Change List ResourceSync document with the changes since this script last ran");
+		options.addOption("r", "rebase", false, "Update the Resource List ResourceSync document to reflect the current state of the archive, and bring the Change List up to the same level");
+		CommandLineParser parser = new PosixParser();
+		CommandLine cmd = parser.parse( options, args);
 
-        Context context = new Context();
-        ResourceSyncGenerator rsg = new ResourceSyncGenerator(context);
+		Context context = new Context();
+		List<String> handles = buildHandleForResourceSync(context);
 
-        try
-        {
-            if (cmd.hasOption("i"))
-            {
-                rsg.init();
-            }
-            else if (cmd.hasOption("u"))
-            {
-                rsg.update();
-            }
-            else if (cmd.hasOption("r"))
-            {
-                rsg.rebase();
-            }
-            else
-            {
-                HelpFormatter hf = new HelpFormatter();
-                hf.printHelp("ResourceSyncGenerator", "Manage ResourceSync documents for DSpace", options, "");
-            }
-        }
-        finally
-        {
-            context.abort();
-        }
-    }
+		ResourceSyncGenerator rsg = new ResourceSyncGenerator(context, handles, null);
 
-    private UrlManager um;
-    private SimpleDateFormat sdf;
-    private Context context;
-    private boolean resourceDump = false;
-    private String outdir;
+		try
+		{
+			if (cmd.hasOption("i"))
+			{
+				rsg.init();
+			}
+			else if (cmd.hasOption("u"))
+			{
+				rsg.update();
+			}
+			else if (cmd.hasOption("r"))
+			{
+				rsg.rebase();
+			}
+			else
+			{
+				HelpFormatter hf = new HelpFormatter();
+				hf.printHelp("ResourceSyncGenerator", "Manage ResourceSync documents for DSpace", options, "");
+			}
+		}
+		finally
+		{
+			context.abort();
+		}
+	}
 
-    public ResourceSyncGenerator(Context context)
-            throws IOException
-    {
-        this.um = new UrlManager();
-        this.sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
-        this.context = context;
-        this.resourceDump = ConfigurationManager.getBooleanProperty("resourcesync", "resourcedump.enable");
-        this.outdir = ConfigurationManager.getProperty("resourcesync", "resourcesync.dir");
-        if (this.outdir == null)
-        {
-            throw new IOException("No configuration for resourcesync.dir");
-        }
-    }
+	private Map<String, UrlManager> ums;
+	public static final  SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
+	public static final  SimpleDateFormat sdfChangeList = new SimpleDateFormat("yyyy-MM-dd-HHmmss");
+	private Context context;
+	private boolean resourceDump = false;
+	private boolean changeDump = false;
+	private String outdir;
+	private List<String> handles = null;
+	private Date fromChangeDump = null; 
 
-    //////////////////////////////////////////////////////////////////////////////
-    // methods to be used to interact with the generator
-    //////////////////////////////////////////////////////////////////////////////
+	public static List<String> buildHandleForResourceSync(Context context) throws SQLException {
+		String capabilityList = ConfigurationManager.getProperty("resourcesync", "capabilitylists");
 
-    public void init()
-            throws IOException, SQLException, ParseException
-    {
-        // make sure that the directory exists, and that it is empty
-        this.ensureResourceSyncDirectory();
-        this.emptyResourceSyncDirectory();
+		List<String> handles = new ArrayList<String>();
+		if(capabilityList.equals("top"))
+		{
+			Community[] communities = Community.findAllTop(context);
+			for (Community c : communities)
+			{
+				handles.add(c.getHandle());
+			}
+			handles.add(Site.getSiteHandle());
+		}
+		else if(capabilityList.equals("all"))
+		{
+			handles.add(Site.getSiteHandle());
+			Community[] communities = Community.findAll(context);
+			for (Community c : communities) 
+			{
+				handles.add(c.getHandle());
+			}
+			Collection[] collections = Collection.findAll(context);
+			for (Collection c : collections) 
+			{
+				handles.add(c.getHandle());
+			}
+		}
+		else if(capabilityList.equals("site"))
+		{
+			handles.add(Site.getSiteHandle());
+		}
+		else
+		{
 
-        // generate the description document (which will point to the not-yet-existent capability list)
-        this.generateResourceSyncDescription();
+			String[] handle = capabilityList.split("\\s+");
 
-        // generate the resource list
-        this.generateResourceList();
+			for (String h : handle) {
+				DSpaceObject dso = HandleManager.resolveToObject(context, h);
+				if (dso == null) 
+				{
+					log.error("The handle isn't valid "+handle);
+				}
+				else if (dso.getType() == Constants.ITEM) 
+				{
+					log.error("Can't use ResourceSync with handle of item "+h);
+				}
+				else 
+				{
+					handles.add(h);
+				}
+			}
+		}
+		return handles;
+	}
 
-        // should we generate a resource dump?
-        if (this.resourceDump)
-        {
-            this.generateResourceDump();
-        }
+	
+	
+	
+	public ResourceSyncGenerator(Context context, List<String> handles, Date fromChangeDump)
+			throws IOException
+	{
+		this.handles = handles;
+		this.ums = new HashMap<String, UrlManager>();
+		for (String h : handles) 
+		{
+			this.ums.put(h, new UrlManager(h));	
+		}
+		this.context = context;
+		this.resourceDump = ConfigurationManager.getBooleanProperty("resourcesync", "resourcedump.enable");
 
-        // generate the capability list (with a resource list, without a change list, and maybe with a resource dump)
-        this.generateCapabilityList(true, false, this.resourceDump, false);
+		this.outdir = ConfigurationManager.getProperty("resourcesync", "resourcesync.dir");
+		if (this.outdir == null)
+		{
+			throw new IOException("No configuration for resourcesync.dir");
+		}
+		this.fromChangeDump = fromChangeDump;
+	}
 
-        // generate the blank changelist as a placeholder for the next iteration
-        this.generateBlankChangeList();
-    }
+	//////////////////////////////////////////////////////////////////////////////
+	// methods to be used to interact with the generator
+	//////////////////////////////////////////////////////////////////////////////
 
-    public void update()
-            throws IOException, SQLException, ParseException
-    {
-        // check the directory is there
-        this.ensureResourceSyncDirectory();
+	public void init()
+			throws IOException, SQLException, ParseException
+	{
+		this.changeDump = false;
+		// make sure that the directory exists, and that it is empty
+		this.ensureResourceSyncDirectory();
+		this.emptyResourceSyncDirectory();
 
-        // generate the latest changelist
-        String clFilename = this.generateLatestChangeList();
+		// generate the description index document
+		this.generateResourceSyncDescriptionIndex(handles);
+		for (String handle : this.handles) {
 
-        // add to the change list archive
-        this.addChangeListToArchive(clFilename);
+			// generate the resource list
+			this.generateResourceList(handle);
 
-        // update the last modified date in the capability list (and add the
-        // changelistarchive if necessary)
-        this.updateCapabilityList();
-    }
+			// generate the description document
+			this.generateResourceSyncDescription(handle);
 
-    public void rebase()
-            throws IOException, SQLException, ParseException
-    {
-        this.ensureResourceSyncDirectory();
+			// should we generate a resource dump?
+			if (this.resourceDump)
+			{
+				this.generateResourceDump(handle);
+			}
+			// generate the capability list (with a resource list, without a change list, and maybe with a resource dump)
+			this.generateCapabilityList(true, false, this.resourceDump, false,this.changeDump,handle);
 
-        // generate the resource list
-        this.generateResourceList();
+			// generate the blank changelist as a placeholder for the next iteration
+			this.generateBlankChangeList(handle);
+		}
+	}
 
-        // should be generate a resource dump?
-        if (this.resourceDump)
-        {
-            this.generateResourceDump();
-        }
+	public void update()
+			throws IOException, SQLException, ParseException
+	{
+		this.changeDump = true;
 
-        // generate the latest changelist
-        String clFilename = this.generateLatestChangeList();
+		// check the directory is there
+		this.ensureResourceSyncDirectory();
+		
+		// generate the latest changelist
+		//		String clFilename = this.generateLatestChangeList();
 
-        // add to the change list archive
-        this.addChangeListToArchive(clFilename);
+		// add to the change list archive
+		String clFilename = null;
+		HashMap<String,String> clFilenameList = new HashMap<String,String>();
+		for (String handle : this.handles) 
+		{
+			
+			List<ResourceSyncEvent> rseListFiltered = new ArrayList<ResourceSyncEvent>();
+			rseListFiltered = getChange(handle);
+			// generate the latest changelist
+			clFilename = this.generateLatestChangeList(handle,rseListFiltered);
+			clFilenameList.put(handle,clFilename);
 
-        // update the last modified date in the capability list (and add the
-        // changelistarchive if necessary)
-        this.updateCapabilityList();
-    }
+			if (this.resourceDump)
+			{
+				this.generateChangeDump(handle,rseListFiltered);
+				//this.generateResourceDump(handle);
+			}
 
-    //////////////////////////////////////////////////////////////////////
-    // file management utility methods
-    //////////////////////////////////////////////////////////////////////
 
-    private void ensureResourceSyncDirectory()
-            throws IOException
-    {
-        // make sure our output directory exists
-        this.ensureDirectory(this.outdir);
-    }
+			// update the last modified date in the capability list (and add the
+			// changelistarchive if necessary)
+			this.updateCapabilityList(handle);
+		}
+		this.addChangeListToArchive(clFilenameList,handles);
+	}
 
-    private void ensureDirectory(String dir)
-            throws IOException
-    {
-        File od = new File(dir);
-        if (!od.exists())
-        {
-            od.mkdir();
-        }
-        if (!od.isDirectory())
-        {
-            throw new IOException(dir + " exists, but is not a directory");
-        }
-    }
+	public void rebase()
+			throws IOException, SQLException, ParseException
+	{
+		this.changeDump = false;
+		// make sure that the directory exists, and that it is empty
+		this.ensureResourceSyncDirectory();
+		this.emptyResourceSyncDirectory();
 
-    private void emptyResourceSyncDirectory()
-            throws IOException
-    {
-        this.emptyDirectory(this.outdir);
-    }
+		// generate the description index document
+		this.generateResourceSyncDescriptionIndex(handles);
+		
+		String clFilename = null;
+		HashMap<String,String> clFilenameList = new HashMap<String,String>();
+		
+		for (String handle : this.handles) {
 
-    private void emptyDirectory(String outdir)
-    {
-        File out = new File(outdir);
-        File[] files = out.listFiles();
-        if (files == null)
-        {
-            return;
-        }
-        for (File f : files)
-        {
-            f.delete();
-        }
-    }
+			// generate the resource list
+			this.generateResourceList(handle);
 
-    private FileOutputStream getFileOutputStream(String filename)
-            throws IOException
-    {
-        String rsdFile = this.outdir + File.separator + filename;
-        FileOutputStream fos = new FileOutputStream(new File(rsdFile));
-        return fos;
-    }
+			// generate the description document
+			this.generateResourceSyncDescription(handle);
 
-    private FileInputStream getFileInputStream(String filename)
-            throws IOException
-    {
-        String file = this.outdir + File.separator + filename;
-        FileInputStream fis = new FileInputStream(new File(file));
-        return fis;
-    }
+			List<ResourceSyncEvent> rseListFiltered = new ArrayList<ResourceSyncEvent>();
+			rseListFiltered = getChange(handle);
+			// generate the latest changelist
+			clFilename = this.generateLatestChangeList(handle,rseListFiltered);
+			clFilenameList.put(handle,clFilename);
+			
+			// should we generate a resource dump?
+			if (this.resourceDump)
+			{
+				this.generateResourceDump(handle);
+			}
+			// generate the capability list (with a resource list, without a change list, and maybe with a resource dump)
+			this.updateCapabilityList(handle);
+		}
+		this.addChangeListToArchive(clFilenameList,handles);
+	}
+	
+	
+	public List<ResourceSyncEvent> getChange(String handle) {
+		Date from = null;
+		try {
+			if (fromChangeDump == null)
+			{
+				from = this.getLastChangeListDate(handle);
+			}else
+			{
+				from = fromChangeDump;
+			}
+		} catch (ParseException e) {
+        	log.error(e.getMessage(),e);
+		}
+		Date to = new Date();
+		List<ResourceSyncEvent> rseList = new ArrayList<ResourceSyncEvent>();
+		ResourceSyncAuditService auditService = new ResourceSyncAuditService();
+		rseList = auditService.listEvents(from, to, handle);
+		return rseList;
+	}
 
-    private void deleteFile(String filename)
-    {
-        File old = new File(this.outdir + File.separator + filename);
-        if (old.exists())
-        {
-            old.delete();
-        }
-    }
 
-    private String getLastChangeListName()
-            throws ParseException
-    {
-        String filename = null;
-        Date from = new Date(0);
-        File dir = new File(this.outdir);
-        File[] files = dir.listFiles();
-        if (files != null)
-        {
-            for (File f : dir.listFiles())
-            {
-                if (FileNames.isChangeList(f))
-                {
-                    String dr = FileNames.changeListDate(f);
-                    Date possibleFrom = this.sdf.parse(dr);
-                    if (possibleFrom.getTime() > from.getTime())
-                    {
-                        from = possibleFrom;
-                        filename = f.getName();
-                    }
-                }
-            }
-        }
-        return filename;
-    }
 
-    private Date getLastChangeListDate()
-            throws ParseException
-    {
-        Date from = new Date(0);
-        File dir = new File(this.outdir);
-        File[] files = dir.listFiles();
-        if (files != null)
-        {
-            for (File f : dir.listFiles())
-            {
-                if (FileNames.isChangeList(f))
-                {
-                    String dr = FileNames.changeListDate(f);
-                    Date possibleFrom = this.sdf.parse(dr);
-                    if (possibleFrom.getTime() > from.getTime())
-                    {
-                        from = possibleFrom;
-                    }
-                }
-            }
-        }
-        return from;
-    }
+	//////////////////////////////////////////////////////////////////////
+	// file management utility methods
+	//////////////////////////////////////////////////////////////////////
 
-    private boolean fileExists(String filename)
-    {
-        String path = this.outdir + File.separator + filename;
-        File file = new File(path);
-        return file.exists() && file.isFile();
-    }
+	private void ensureResourceSyncDirectory()
+			throws IOException
+	{
+		// make sure our output directory exists
+		this.ensureDirectory(this.outdir);
+	}
 
-    ////////////////////////////////////////////////////////////////////
-    // private document generation methods
-    ////////////////////////////////////////////////////////////////////
+	private void ensureDirectory(String dir)
+			throws IOException
+	{
+		File od = new File(dir);
+		if (!od.exists())
+		{
+			od.mkdir();
+		}
+		if (!od.isDirectory())
+		{
+			throw new IOException(dir + " exists, but is not a directory");
+		}
+	}
 
-    private void generateResourceSyncDescription()
-            throws IOException
-    {
-        FileOutputStream fos = this.getFileOutputStream(FileNames.resourceSyncDocument);
+	private void emptyResourceSyncDirectory()
+			throws IOException
+	{
+		this.emptyDirectory(this.outdir);
+	}
+	private void deleteFolder(File folder) {
+		File[] files = folder.listFiles();
+		if(files!=null) {
+			for(File f: files) {
+				if(f.isDirectory()) {
+					deleteFolder(f);
+				} else {
+					f.delete();
+				}
+			}
+		}
+		folder.delete();
+	}
+	private void emptyDirectory(String outdir)
+	{
+		File out = new File(outdir);
+		File[] files = out.listFiles();
+		if (files == null)
+		{
+			return;
+		}
+		for (File f : files)
+		{
+			if(f.isDirectory()) {
+				deleteFolder(f);
+			} else {
+				f.delete();            }
+		}
+	}
 
-        // no need for a DSpace-specific implementation, it is so simple
-        ResourceSyncDescription desc = new ResourceSyncDescription();
-        desc.addCapabilityList(this.um.capabilityList());
-        desc.serialise(fos);
+	private FileOutputStream getFileOutputStream(String filename)
+			throws IOException
+	{
+		FileOutputStream fos = new FileOutputStream(new File(this.outdir+File.separator+filename));
+		return fos;
+	}
 
-        fos.close();
-    }
+	private FileOutputStream getFileOutputStream(String filename, String handle)
+			throws IOException
+	{
+		String rsdFile = getOutdir(handle) + File.separator + filename;
+		FileOutputStream fos = new FileOutputStream(new File(rsdFile));
+		return fos;
+	}
 
-    private void updateCapabilityList()
-            throws IOException, ParseException
-    {
-        // just regenerate the capability list in its entirity
-        this.generateCapabilityList(true, true, this.resourceDump, true);
-    }
+	private String getOutdir(String handle) {
+		if (handle != null && !Site.getSiteHandle().equals(handle)) {
+			return this.outdir + File.separator + handle.replaceAll("/", "-");
+		}
+		return this.outdir;
+	}
 
-    private void generateCapabilityList(boolean resourceList, boolean changeListArchive, boolean resourceDump, boolean changeList)
-            throws IOException, ParseException
-    {
-        // get the latest change list if there is one and we want one
-        String changeListUrl = null;
-        if (changeList)
-        {
-            String clFilename = this.getLastChangeListName();
-            changeListUrl = this.um.changeList(clFilename);
-        }
 
-        FileOutputStream fos = this.getFileOutputStream(FileNames.capabilityList);
+	private void deleteFile(String filename)
+	{
+		File old = new File(this.outdir + File.separator + filename);
+		if (old.exists())
+		{
+			old.delete();
+		}
+	}
+	private String getLastChangeDumpName(String handle)
+			throws ParseException
+	{
+		String filename = null;
+		Date from = new Date(0);
+		File dir;
+		if (handle != Site.getSiteHandle())
+		{
+			dir = new File(this.outdir+File.separator+handle.replace("/", "-"));
+		}
+		else{
+			dir = new File(this.outdir);
+		}
+		File[] files = dir.listFiles();
+		if (files != null)
+		{
+			for (File f : dir.listFiles())
+			{
+				if (FileNames.isChangeDump(f))
+				{
+					String dr = FileNames.changeDumpDate(f);
+					Date possibleFrom = ResourceSyncGenerator.sdfChangeList.parse(dr);
+					if (possibleFrom.getTime() > from.getTime())
+					{
+						from = possibleFrom;
+						filename = f.getName();
+					}
+				}
+			}
+		}
+		return filename;
+	}
+	private String getLastChangeListName(String handle)
+			throws ParseException
+	{
+		String filename = null;
+		Date from = new Date(0);
+		File dir;
+		if (handle != Site.getSiteHandle())
+		{
+			dir = new File(this.outdir+File.separator+handle.replace("/", "-"));
+		}
+		else{
+			dir = new File(this.outdir);
+		}
+		File[] files = dir.listFiles();
+		if (files != null)
+		{
+			for (File f : dir.listFiles())
+			{
+				if (FileNames.isChangeList(f))
+				{
+					String dr = FileNames.changeListDate(f);
+					Date possibleFrom = ResourceSyncGenerator.sdfChangeList.parse(dr);
+					if (possibleFrom.getTime() > from.getTime())
+					{
+						from = possibleFrom;
+						filename = f.getName();
+					}
+				}
+			}
+		}
+		return filename;
+	}
 
-        DSpaceCapabilityList dcl = new DSpaceCapabilityList(this.context, resourceList, changeListArchive, resourceDump, changeList, changeListUrl);
-        dcl.serialise(fos);
+	private Date getLastChangeListDate(String handle)
+			throws ParseException
+	{
+		File dir = new File(getOutdir(handle));
+		Date from = new Date(0);
+		File[] files = dir.listFiles();
+		if (files != null)
+		{
+			for (File f : dir.listFiles())
+			{
+				if (FileNames.isChangeList(f))
+				{
+					String dr = FileNames.changeListDate(f);
+					Date possibleFrom = ResourceSyncGenerator.sdfChangeList.parse(dr);
+					if (possibleFrom.getTime() > from.getTime())
+					{
+						from = possibleFrom;
+					}
+				}
+			}
+		}
+		return from;
+	}
 
-        fos.close();
-    }
+	private boolean fileExists(String filename)
+	{
+		String path = this.outdir + File.separator + filename;
+		File file = new File(path);
+		return file.exists() && file.isFile();
+	}
 
-    private void generateResourceList()
-            throws SQLException, IOException
-    {
-        FileOutputStream fos = this.getFileOutputStream(FileNames.resourceList);
+	////////////////////////////////////////////////////////////////////
+	// private document generation methods
+	////////////////////////////////////////////////////////////////////
 
-        DSpaceResourceList drl = new DSpaceResourceList(this.context);
-        drl.serialise(fos);
+	private void generateResourceSyncDescriptionIndex( List<String> handles)
+			throws IOException
+	{
+		FileOutputStream fos = this.getFileOutputStream(FileNames.resourceSyncDocumentIndex);
 
-        fos.close();
-    }
+		// no need for a DSpace-specific implementation, it is so simple
+		ResourceSyncDescriptionIndex desc = new ResourceSyncDescriptionIndex(ResourceSync.CAPABILITY_RESOURCESYNC);
+		for (String h: handles)
+		{
+			desc.addSourceDescription((this.ums.get(h).resourceSyncDescription()));
+		}
+		desc.serialise(fos);
+		
+		fos.close();
+		
+	}
 
-    private void generateResourceDump()
-            throws IOException, SQLException
-    {
-        this.deleteFile(FileNames.resourceDump);
-        this.deleteFile(FileNames.resourceDumpZip);
+	private void generateResourceSyncDescription( String handle)
+			throws IOException
+	{
+		FileOutputStream fos = this.getFileOutputStream(FileNames.resourceSyncDocument,handle);
 
-        DSpaceResourceDump drd = new DSpaceResourceDump(this.context);
-        drd.serialise(this.outdir);
-    }
+		// no need for a DSpace-specific implementation, it is so simple
+		ResourceSyncDescription desc = new ResourceSyncDescription();
+		desc.addCapabilityList(this.ums.get(handle).capabilityList());
+		desc.serialise(fos);
 
-    private String generateLatestChangeList()
-            throws ParseException, IOException, SQLException
-    {
-        // determine the "from" date by looking at existing changelists
-        Date from = this.getLastChangeListDate();
+		fos.close();
+	}
 
-        // the "to" date is now, and we'll also use that in the filename, so get the
-        // string representation
-        Date to = new Date();
-        String tr = sdf.format(to);
 
-        // create the changelist name for the period
-        String filename = FileNames.changeList(tr);
-        FileOutputStream fos = this.getFileOutputStream(filename);
 
-        // generate the changelist for the period
-        DSpaceChangeList dcl = new DSpaceChangeList(this.context, from, to);
-        dcl.serialise(fos);
-        fos.close();
+	private void updateCapabilityList(String handle)
+			throws IOException, ParseException
+	{
+		// just regenerate the capability list in its entirity
+		this.generateCapabilityList(true, false, this.resourceDump, true,this.changeDump,handle);
+	}
 
-        return filename;
-    }
+	private void generateCapabilityList(boolean resourceList, boolean changeListArchive, boolean resourceDump,
+			boolean changeList,boolean changeDump,String handle)
+					throws IOException, ParseException
+	{
+		// get the latest change list if there is one and we want one
+		String changeListUrl = null;
+		String changeDumpUrl = null;
+		if (changeList)
+		{
+			String clFilename = this.getLastChangeListName(handle);
+			changeListUrl = this.ums.get(handle).changeList(clFilename);
+			
+		}
+		if (changeDump)
+		{
+			String cdFilename = this.getLastChangeDumpName(handle);
+			changeDumpUrl = this.ums.get(handle).changeDump(cdFilename);
+		}
+		FileOutputStream fos = this.getFileOutputStream(FileNames.capabilityList,handle);
 
-    private void generateBlankChangeList()
-            throws IOException, SQLException, ParseException
-    {
-        Date to = new Date();
-        String tr = this.sdf.format(to);
+		DSpaceCapabilityList dcl = new DSpaceCapabilityList(this.context, resourceList, changeListArchive,
+				resourceDump, changeList, changeDump, changeListUrl,changeDumpUrl,ums.get(handle));
+		dcl.serialise(fos);
 
-        FileOutputStream fos = this.getFileOutputStream(FileNames.changeList(tr));
+		fos.close();
+	}
 
-        // generate the changelist for the period (which is of 0 length)
-        DSpaceChangeList dcl = new DSpaceChangeList(this.context, to, to);
-        dcl.serialise(fos);
+	private void generateResourceList(String handle)
+			throws SQLException, IOException
+	{
+		String directoryName;
+		String path;
+		if (!handle.equals(Site.getSiteHandle()))
+		{
+			directoryName = handle.replace("/", "-");
+			path = ConfigurationManager.getProperty("resourcesync", "resourcesync.dir");
+			path = path.concat("/"+directoryName);		
+			File directory = new File(path);
+			directory.mkdir();
+		}
+		FileOutputStream fos = this.getFileOutputStream(File.separator+FileNames.resourceList,handle);
 
-        fos.close();
-    }
+		DSpaceResourceList drl = new DSpaceResourceList(this.context);
+		drl.serialise(fos,handle,this.ums.get(handle));
 
-    private void addChangeListToArchive(String filename)
-            throws IOException, ParseException
-    {
-        // get the URL of the new changelist
-        String loc = this.um.changeList(filename);
+		fos.close();
+	}
+    
+	private void generateResourceDump(String handle)
+			throws IOException, SQLException
+	{
+		if (handle.equals(Site.getSiteHandle()))
+		{
+			this.deleteFile(FileNames.resourceDump);
+			this.deleteFile(FileNames.resourceDumpZip);
+		}
+		DSpaceResourceDump drd = new DSpaceResourceDump(this.context);
+		drd.serialise(getOutdir(handle), handle, ums.get(handle));
+	}
+	private void generateChangeDump(String handle,List<ResourceSyncEvent> rseList)
+			throws IOException, SQLException
+	{
+		DSpaceChangeDump drd = new DSpaceChangeDump(this.context);
+		drd.serialiseChangeDump(getOutdir(handle), ums.get(handle),rseList);
+	}
+	public void generateChangeDump(String handle,List<ResourceSyncEvent> rseList,OutputStream os)
+			throws IOException, SQLException
+	{
+		DSpaceChangeDump drd = new DSpaceChangeDump(this.context);
+		drd.serialiseChangeDump(getOutdir(handle), ums.get(handle),rseList,os);
+	}
 
-        // get the date of the new changelist (it is encoded in the filename)
-        String dr = FileNames.changeListDate(filename);
-        Date date = this.sdf.parse(dr);
+	private String generateLatestChangeList(String handle,List<ResourceSyncEvent> rseListFiltered)
+			throws ParseException, IOException, SQLException
+	{
+		
+		Date from = this.getLastChangeListDate(handle);
+		Date to = new Date();
+		String tr = sdfChangeList.format(to);
+		String filename = FileNames.changeList(tr);
+		FileOutputStream fos = this.getFileOutputStream(filename,handle);
+		DSpaceChangeList dcl = new DSpaceChangeList(this.context, from, to,ums.get(handle)); //TO-DO
+		dcl.serialiseForDump(fos,ums.get(handle),rseListFiltered);
 
-        DSpaceChangeListArchive dcla = new DSpaceChangeListArchive(this.context);
-        dcla.addChangeList(loc, date);
+		return filename;
+	}
 
-        // if the change list archive exists and is a file, we need to
-        // read it in as a change list
-        if (this.fileExists(FileNames.changeListArchive))
-        {
-            // read the ChangeListArchive
-            FileInputStream fis = this.getFileInputStream(FileNames.changeListArchive);
-            dcla.readInSource(fis);
-            fis.close();
-        }
+	private void generateBlankChangeList(String handle)
+			throws IOException, SQLException, ParseException
+	{
 
-        FileOutputStream fos = this.getFileOutputStream(FileNames.changeListArchive);
-        dcla.serialise(fos);
-        fos.close();
-    }
+		Date to = new Date();
+		String tr = ResourceSyncGenerator.sdfChangeList.format(to);
+
+		FileOutputStream fos = this.getFileOutputStream(FileNames.changeList(tr),handle);
+
+		// generate the changelist for the period (which is of 0 length)
+		DSpaceChangeList dcl = new DSpaceChangeList(this.context, to, to,ums.get(handle));
+		dcl.serialise(fos);
+		fos.close();
+	}
+
+	private void addChangeListToArchive(HashMap<String,String> filename,List<String> handles)
+			throws IOException, ParseException
+	{
+		
+		DSpaceChangeListArchive dcla = new DSpaceChangeListArchive(this.context);
+		dcla.setUm(ums.get(Site.getSiteHandle()));
+		FileOutputStream fos = this.getFileOutputStream(FileNames.changeListArchive,Site.getSiteHandle());
+		
+		for(String handle : handles)
+		{
+			// get the URL of the new changelist
+			String loc = this.ums.get(handle).changeList(filename.get(handle));
+
+			// get the date of the new changelist (it is encoded in the filename)
+			String dr = FileNames.changeListDate(filename.get(handle));
+			Date date = ResourceSyncGenerator.sdfChangeList.parse(dr);
+
+			dcla.addChangeList(loc, date);
+		}
+		dcla.serialise(fos);
+
+		fos.close();
+	}
 }

--- a/src/main/java/org/dspace/resourcesync/ResourceSyncGenerator.java
+++ b/src/main/java/org/dspace/resourcesync/ResourceSyncGenerator.java
@@ -1,3 +1,8 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree
+ */
 package org.dspace.resourcesync;
 
 import org.apache.commons.cli.CommandLine;
@@ -18,7 +23,10 @@ import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 
-
+/**
+ * @author Richard Jones
+ *
+ */
 public class ResourceSyncGenerator
 {
     public static void main(String[] args)

--- a/src/main/java/org/dspace/resourcesync/ResourceSyncServlet.java
+++ b/src/main/java/org/dspace/resourcesync/ResourceSyncServlet.java
@@ -1,3 +1,8 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree
+ */
 package org.dspace.resourcesync;
 
 import org.dspace.authorize.AuthorizeException;
@@ -26,6 +31,10 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.sql.SQLException;
 
+/**
+ * @author Richard Jones
+ *
+ */
 public class ResourceSyncServlet extends HttpServlet
 {
     @Override

--- a/src/main/java/org/dspace/resourcesync/UrlManager.java
+++ b/src/main/java/org/dspace/resourcesync/UrlManager.java
@@ -1,7 +1,16 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree
+ */
 package org.dspace.resourcesync;
 
 import org.dspace.core.ConfigurationManager;
 
+/**
+ * @author Richard Jones
+ *
+ */
 public class UrlManager
 {
     private String base;

--- a/src/main/java/org/dspace/resourcesync/UrlManager.java
+++ b/src/main/java/org/dspace/resourcesync/UrlManager.java
@@ -5,6 +5,7 @@
  */
 package org.dspace.resourcesync;
 
+import org.dspace.content.Site;
 import org.dspace.core.ConfigurationManager;
 
 /**
@@ -13,14 +14,22 @@ import org.dspace.core.ConfigurationManager;
  */
 public class UrlManager
 {
-    private String base;
+    private String base;  
 
-    public UrlManager()
+    public UrlManager() {
+    	
+    }
+    public UrlManager(String handle)
     {
         this.base = ConfigurationManager.getProperty("resourcesync", "base-url");
         if (!this.base.endsWith("/"))
         {
             this.base += "/";
+        }
+        if (handle != null && !handle.equals(Site.getSiteHandle()))
+        {
+            String dir = handle.replace("/", "-");
+        	this.base += dir + "/";
         }
     }
 
@@ -53,9 +62,13 @@ public class UrlManager
     {
         return this.base + FileNames.resourceDump;
     }
-
+    
     public String resourceDumpZip()
     {
         return this.base + FileNames.resourceDumpZip;
+    }
+    public String changeDump(String filename)
+    {
+    	return this.base + filename;
     }
 }

--- a/src/main/resources/spring/spring-dspace-addon-resourcesync-services.xml
+++ b/src/main/resources/spring/spring-dspace-addon-resourcesync-services.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    The contents of this file are subject to the license and copyright
+    detailed in the LICENSE and NOTICE files at the root of the source
+    tree
+
+-->
+<beans xmlns="http://www.springframework.org/schema/beans"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:context="http://www.springframework.org/schema/context"
+    xsi:schemaLocation="http://www.springframework.org/schema/beans
+           http://www.springframework.org/schema/beans/spring-beans-2.5.xsd
+           http://www.springframework.org/schema/context
+           http://www.springframework.org/schema/context/spring-context-2.5.xsd"
+    default-autowire-candidates="*Service,*DAO,javax.sql.DataSource">
+
+    <bean class="org.dspace.resourcesync.ResourceSyncAuditService" id="org.dspace.resourcesync.ResourceSyncAuditService"/>
+
+</beans>

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -10,56 +10,66 @@
 
 <web-app>
 
-    <display-name>DSpace ResourceSync Server</display-name>
+	<display-name>DSpace ResourceSync Server</display-name>
 
-    <context-param>
-        <param-name>dspace-config</param-name>
-        <param-value>${dspace.dir}/config/dspace.cfg</param-value>
-        <description>
-            The location of the main DSpace configuration file
-        </description>
-    </context-param>
+	<context-param>
+		<param-name>dspace-config</param-name>
+		<param-value>${dspace.dir}/config/dspace.cfg</param-value>
+		<description>
+			The location of the main DSpace configuration file
+		</description>
+	</context-param>
 
-    <!-- new ConfigurationService initialization for dspace.dir -->
-    <context-param>
-        <description>
-            The location of the main DSpace directory
-        </description>
-        <param-name>dspace.dir</param-name>
-        <param-value>${dspace.dir}</param-value>
-    </context-param>
+	<!-- new ConfigurationService initialization for dspace.dir -->
+	<context-param>
+		<description>
+			The location of the main DSpace directory
+		</description>
+		<param-name>dspace.dir</param-name>
+		<param-value>${dspace.dir}</param-value>
+	</context-param>
 
-    <!--
-       Listener to initialise DSpace configuration and clean up the application
-       -->
-    <listener>
-        <listener-class>
-            org.dspace.servicemanager.servlet.DSpaceKernelServletContextListener
-        </listener-class>
-    </listener>
-    <listener>
-        <listener-class>
-            org.dspace.app.util.DSpaceContextListener
-        </listener-class>
-    </listener>
+	<!-- Listener to initialise DSpace configuration and clean up the application -->
+	<listener>
+		<listener-class>
+			org.dspace.servicemanager.servlet.DSpaceKernelServletContextListener
+		</listener-class>
+	</listener>
+	<listener>
+		<listener-class>
+			org.dspace.app.util.DSpaceContextListener
+		</listener-class>
+	</listener>
 
 
-    <!-- Servlets -->
-    <servlet>
-        <servlet-name>resourcesync</servlet-name>
-        <servlet-class>org.dspace.resourcesync.ResourceSyncServlet</servlet-class>
-    </servlet>
+	<!-- Servlets -->
+	<servlet>
+		<servlet-name>resourcesync</servlet-name>
+		<servlet-class>org.dspace.resourcesync.ResourceSyncServlet</servlet-class>
+	</servlet>
 
-    <!-- Servlet Mappings -->
+	<servlet>
+		<servlet-name>bitstream-retrieve</servlet-name>
+		<servlet-class>org.dspace.resourcesync.BitstreamRetrieveServlet</servlet-class>
+	</servlet>
+	<!-- Servlet Mappings -->
 
-    <servlet-mapping>
-        <servlet-name>default</servlet-name>
-        <url-pattern>/about.txt</url-pattern>
-    </servlet-mapping>
+	<servlet-mapping>
+		<servlet-name>default</servlet-name>
+		<url-pattern>/about.txt</url-pattern>
+	</servlet-mapping>
+	
+	<servlet-mapping>
+		<servlet-name>bitstream-retrieve</servlet-name>
+		<url-pattern>/bitstreams/*</url-pattern>
+	</servlet-mapping>
 
-    <servlet-mapping>
-        <servlet-name>resourcesync</servlet-name>
-        <url-pattern>/*</url-pattern>
-    </servlet-mapping>
+	<servlet-mapping>
+		<servlet-name>resourcesync</servlet-name>
+		<url-pattern>/*</url-pattern>
+	</servlet-mapping>
+
+
+
 
 </web-app>

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -3,9 +3,7 @@
 
     The contents of this file are subject to the license and copyright
     detailed in the LICENSE and NOTICE files at the root of the source
-    tree and available online at
-
-    http://www.dspace.org/license/
+    tree
 
 -->
 <!DOCTYPE web-app PUBLIC "-//Sun Microsystems, Inc.//DTD Web Application 2.3//EN" "http://java.sun.com/dtd/web-app_2_3.dtd">

--- a/src/main/webapp/about.txt
+++ b/src/main/webapp/about.txt
@@ -1,3 +1,9 @@
+====
+    The contents of this file are subject to the license and copyright
+    detailed in the LICENSE and NOTICE files at the root of the source
+    tree
+====
+
 #ResourceSync for Metadata Harvesting
 
 This repository supports the ResourceSync protocol and the profile of ResourceSync for metadata harvesting.


### PR DESCRIPTION
We have resumed the implementation updating it to the latest 1.1 version of the framework.

Other than the general update to version 1.1, we have introduced also the following improvements
1) we have separate capability lists for each "previous" oai-pmh set (DSpace communities and collections), plus a capability list for the whole repository. For each capability lists we have two flavors: one metadata-only and one "full" (metadata + content)
2) changelists are available potentially forever and build on-the-fly so that they contains always the latest changes. A new SOLR core has been introduced to record the audit need to rs
3) dumps (resourcedump & changedump) can be prepared in advance using batch scripts or *produced and streamed to the rs client on the fly* saving storage space. 

This PR is only intent to reflect the agreement with @richard-jones to move the project ahead and offer it to the DSpace community for general inclusion.
To simplify the build process, we are going to copy this repository inside the DSpace project as a new mvn module and open a PR to the DSpace project for inclusion. In this later form different branches/PRs will be created to support version 5, 6 and 7 (the master branch)